### PR TITLE
make `make buildrpm' work fine on CentOS 5 and 6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ install:
 buildrpm: sdist
 	python setup.py bdist_rpm \
 		--post-install=rpm/postinstall \
-		--pre-uninstall=rpm/preuninstall
+		--pre-uninstall=rpm/preuninstall \
+		--install-script=rpm/install
 
 builddeb: sdist
 	mkdir -p build

--- a/rpm/install
+++ b/rpm/install
@@ -1,0 +1,6 @@
+%{__python} setup.py install -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+
+%if ! (0%{?fedora} > 12 || 0%{?rhel} > 5)
+%{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
+%endif

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ else:
 data_files=[
     ('/etc/diamond',                           glob('conf/*.conf*') ),
     ('/etc/diamond/collectors',                glob('conf/collectors/*') ),
-    ('share/diamond',                          ['test.py', 'LICENSE', 'README.md'] ),
+    ('share/diamond',                          ['LICENSE', 'README.md'] ),
     ('share/diamond/user_scripts',             [] ),
 ]
 
@@ -49,5 +49,6 @@ setup(
     packages        = ['diamond'],
     scripts         = glob('bin/*'),
     data_files      = data_files,
+    test_suite      = 'test.main',
     **setup_kwargs
 )


### PR DESCRIPTION
This fixes BrighcoveOS/Diamond#12
