### PR TITLE
HAProxyCollector: return metrics if there isn't an error

### DIFF
--- a/src/collectors/HAProxyCollector/HAProxyCollector.py
+++ b/src/collectors/HAProxyCollector/HAProxyCollector.py
@@ -22,7 +22,7 @@ class HAProxyCollector(diamond.collector.Collector):
         req  = urllib2.Request(self.config['url'])
         try:
             handle = urllib2.urlopen(req)
-            metrics = handle.readlines()
+            return handle.readlines()
         except Exception, e:
             if not hasattr(e, 'code') or e.code != 401:
                 self.log.error("Error retrieving HAProxy stats. %s", e)


### PR DESCRIPTION
In the case where no exception is raised the collector was not returning the metrics but hitting the path that would try an authenticated request. The processing would then fail since the request did not have an  `www-authenticate` header. 
