### PR TITLE
use /usr/bin/diamond in startup script

### DIFF
--- a/debian/upstart/diamond
+++ b/debian/upstart/diamond
@@ -9,7 +9,6 @@ stop on runlevel [!2345]
 respawn
 
 script
-    PYTHONLIB=$(/usr/bin/env python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
-    exec /usr/bin/python ${PYTHONLIB}/diamond/server.py --foreground
+    /usr/bin/python /usr/bin/diamond --foreground
 end script
 


### PR DESCRIPTION
server.py do not hold `__main__` handling anymore, which cause this upstart script to respawn until it's disabled by upstart.

Please rename this file to diamond.conf
As I says here:

https://github.com/BrightcoveOS/Diamond/pull/29

It's required for Ubuntu since a long time
