### PR TITLE
Remove new line before end of LSB init info

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -8,7 +8,6 @@
 # Short-Description: System statistics collector for Graphite.
 # Description:       Diamond is a daemon and toolset for gathering system statistics
 #                    and publishing them to Graphite.
-
 ### END INIT INFO
 
 # Author: Ivan Pouzyrevsky <sandello@yandex-team.ru>


### PR DESCRIPTION
Fixes a Lintian build error mentioned in #43
