### PR TITLE
This collector collects from NUT, the Linux UPS daemon

### DIFF
--- a/src/collectors/UPSCollector/UPSCollector.py
+++ b/src/collectors/UPSCollector/UPSCollector.py
@@ -1,0 +1,42 @@
+from diamond import *
+import diamond.collector
+
+import subprocess
+
+class UPSCollector(diamond.collector.Collector):
+    """
+    This class collects data from NUT, a UPS interface for linux.
+
+    Requires: nut/upsc to be installed, configured and running.
+    """
+
+    def get_default_config(self):
+        """
+        Returns default collector settings.
+        """
+
+        return {
+            'enabled': 'True',
+            'path': 'ups',
+            'ups_name': 'cyberpower'
+        }
+
+    def collect(self):
+        p = subprocess.Popen(['/bin/upsc', self.config['ups_name']], stdout=subprocess.PIPE)
+
+        for ln in p.communicate()[0].splitlines():
+            datapoint = ln.split(": ")
+
+            try:
+                val = float(datapoint[1])
+            except:
+                continue
+
+            if len(datapoint[0].split(".")) == 2:
+                # If the metric name is the same as the subfolder
+                # double it so it's visible.
+                name = ".".join([datapoint[0], datapoint[0].split(".")[1]])
+            else:
+                name = datapoint[0]
+
+            self.publish(name, val)


### PR DESCRIPTION
This is a really simple collector that depends on you having installed and configured NUT/UPSC, which will allow you to call /bin/upsc and gather a variety of metrics. The collector preserves the upsc output format, with two changes: only numeric data is sent to Graphite (of course), and upsc sometimes outputs metrics in a way that's incompatible with Graphite. These are auto-corrected.
