### PR TITLE
SensorsCollector, which collects data from libsensors via PySensors

### DIFF
--- a/src/collectors/SensorsCollector/SensorsCollector.py
+++ b/src/collectors/SensorsCollector/SensorsCollector.py
@@ -1,0 +1,34 @@
+import diamond.collector
+
+import sensors
+
+class SensorsCollector(diamond.collector.Collector):
+    """
+    This class collects data from libsensors. It should work against libsensors 2.x and 3.x, pending
+    support within the PySensors Ctypes binding: http://pypi.python.org/pypi/PySensors/
+
+    Requires: 'sensors' to be installed, configured, and the relevant kernel modules to be loaded.
+    Requires: PySensors requires Python 2.6+
+
+    If you're having issues, check your version of 'sensors'. This collector written against:
+    sensors version 3.1.2 with libsensors version 3.1.2
+    """
+
+    def get_default_config(self):
+        """
+        Returns default collector settings.
+        """
+        return {
+            'enabled': 'True',
+            'path': 'sensors',
+            'fahrenheit': 'True'
+        }
+
+    def collect(self):
+        sensors.init()
+        try:
+            for chip in sensors.iter_detected_chips():
+                for feature in chip:
+                    self.publish(".".join([str(chip), feature.label]), feature.get_value())
+        finally:
+            sensors.cleanup()


### PR DESCRIPTION
This is very simple collector that gathers system sensors data from libsensors (lm-sensors) via PySensors. 

It depends on PySensors and lm-sensors being installed.

PySensors can be found here: http://pypi.python.org/pypi/PySensors/
lm-sensors is generally installed as an OS package.

A drawback of this collector is that PySensors currently requires Python 2.6+ (which excludes RHEL by default), but a different libsensors binding could be used in the future, as this collector only has 5 lines of code depending on PySensors.
