### PR TITLE
Python 2.6 fixes

### DIFF
--- a/src/collectors/ConnTrackCollector/ConnTrackCollector.py
+++ b/src/collectors/ConnTrackCollector/ConnTrackCollector.py
@@ -25,7 +25,7 @@ class ConnTrackCollector(diamond.collector.Collector):
     def collect(self):
         if not os.access(COMMAND[0], os.X_OK):
             return
-        line = subprocess.check_output(ConnTrackCollector.COMMAND)
+        line = subprocess.Popen(ConnTrackCollector.COMMAND, stdout=subprocess.PIPE).communicate()[0]
         match = _RE.match(line)
         if match:
             self.publish('nf_conntrack_count', int(match.group(2)))

--- a/src/collectors/VarnishCollector/VarnishCollector.py
+++ b/src/collectors/VarnishCollector/VarnishCollector.py
@@ -50,7 +50,7 @@ class VarnishCollector(diamond.collector.Collector):
         data = {}
         if not os.access(self._CMD, os.X_OK):
             return data
-        output = subprocess.check_output([self._CMD, '-1'])
+        output = subprocess.Popen([self._CMD, '-1'], stdout=subprocess.PIPE).communicate()[0]
         matches = self._RE.findall(output)
         for line in matches:
             if line[0] in self._KEYS:


### PR DESCRIPTION
Varnish and Conntrack collectors fixed to work with Python 2.6 (ships with el6).
