### PR TITLE
Added statsd support

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -86,6 +86,8 @@ class Collector(object):
             hostname.reverse()
             hostname = '.'.join(hostname)
             return hostname
+        if self.config['hostname_method'].lower() == 'none':
+            return None
         raise NotImplementedError()
 
     def get_metric_path(self, name):
@@ -96,8 +98,10 @@ class Collector(object):
             prefix = self.config['path_prefix']
         else:
             prefix = 'systems'
-            
+
         hostname = self.get_hostname()
+        if hostname is not None:
+            prefix = prefix + "." + hostname
 
         if 'path' in self.config:
             path = self.config['path']
@@ -105,9 +109,9 @@ class Collector(object):
             path = self.__class__.__name__
 
         if path == '.':
-            return '.'.join([prefix, hostname, name])
+            return '.'.join([prefix, name])
         else:
-            return '.'.join([prefix, hostname, path, name])
+            return '.'.join([prefix, path, name])
 
     def collect(self):
         """

--- a/src/diamond/handler/StatsdHandler.py
+++ b/src/diamond/handler/StatsdHandler.py
@@ -1,0 +1,57 @@
+from Handler import Handler
+import statsd
+import logging
+
+
+class StatsdHandler(Handler):
+    """
+    Implements the abstract Handler class, sending data to statsd.
+    This is a UDP service, sending datagrams.  They may be lost.
+    It's OK.
+    """
+    def __init__(self, config=None):
+        """
+        Create a new instance of the StatsdHandler class
+        """
+        # Initialize Handler
+        Handler.__init__(self, config)
+        logging.debug("Initialized statsd handler.")
+        # Initialize Options
+        self.host = self.config['host']
+        self.port = int(self.config['port'])
+
+        # Connect
+        self._connect()
+
+    def process(self, metric):
+        """
+        Process a metric by sending it to statsd
+        """
+        # Acquire lock
+        self.lock.acquire()
+        # Just send the data as a string
+        self._send(metric)
+        # Release lock
+        self.lock.release()
+
+    def _send(self, metric):
+        """
+        Send data to statsd. Fire and forget.  Cross fingers and it'll arrive.
+        """
+        # Split the path into a prefix and a name
+        # to work with the statsd module's view of the world.
+        # It will get re-joined by the python-statsd module.
+        (prefix, name) = metric.path.rsplit(".", 1)
+        logging.debug("Sending {0} {1} {2}|r".format(name, metric.value, metric.timestamp))
+        statsd.Raw(prefix, self.connection).send(name, metric.value, metric.timestamp)
+
+    def _connect(self):
+        """
+        Connect to the statsd server
+        """
+        # Create socket
+        self.connection = statsd.Connection(
+            host=self.host,
+            port=self.port,
+            sample_rate=1.0
+        )


### PR DESCRIPTION
collector - added a "None" option for hostname type.  This allows for
everything to be set in the prefix so naming can be gotten from
external config pretty easily - e.g. via amazon aws EC2 instance IDs.

StatsdHandler.py - added a handler that delivers to statsd.  This requires
a version of the python-statsd module that has the "raw" type added and a 
statsd with this stats type implemented.    Both of these are in pull requests 
with their respective maintainers.
