### PR TITLE
Allow explicit network device name matching

### DIFF
--- a/src/collectors/NetworkCollector/NetworkCollector.py
+++ b/src/collectors/NetworkCollector/NetworkCollector.py
@@ -43,6 +43,7 @@ class NetworkCollector(diamond.collector.Collector):
             'path':         'network',
             'interfaces':   'eth bond',
             'byte_unit':    'megabit megabyte',
+            'greedy':       'true',
         }
 
     def collect(self):
@@ -58,7 +59,8 @@ class NetworkCollector(diamond.collector.Collector):
             # Open File
             file = open(self.PROC)
             # Build Regular Expression
-            exp = '^(?:\s*)([%s0-9]+):(?:\s*)(?P<rx_bytes>\d+)(?:\s*)(?P<rx_packets>\w+)(?:\s*)(?P<rx_errors>\d+)(?:\s*)(?P<rx_drop>\d+)(?:\s*)(?P<rx_fifo>\d+)(?:\s*)(?P<rx_frame>\d+)(?:\s*)(?P<rx_compressed>\d+)(?:\s*)(?P<rx_multicast>\d+)(?:\s*)(?P<tx_bytes>\d+)(?:\s*)(?P<tx_packets>\w+)(?:\s*)(?P<tx_errors>\d+)(?:\s*)(?P<tx_drop>\d+)(?:\s*)(?P<tx_fifo>\d+)(?:\s*)(?P<tx_frame>\d+)(?:\s*)(?P<tx_compressed>\d+)(?:\s*)(?P<tx_multicast>\d+)(?:.*)$' % ( '|'.join(self.config['interfaces']) )
+            greed = '0-9' if self.config['greedy'].lower == 'true' else ''
+            exp = '^(?:\s*)([%s%s]+):(?:\s*)(?P<rx_bytes>\d+)(?:\s*)(?P<rx_packets>\w+)(?:\s*)(?P<rx_errors>\d+)(?:\s*)(?P<rx_drop>\d+)(?:\s*)(?P<rx_fifo>\d+)(?:\s*)(?P<rx_frame>\d+)(?:\s*)(?P<rx_compressed>\d+)(?:\s*)(?P<rx_multicast>\d+)(?:\s*)(?P<tx_bytes>\d+)(?:\s*)(?P<tx_packets>\w+)(?:\s*)(?P<tx_errors>\d+)(?:\s*)(?P<tx_drop>\d+)(?:\s*)(?P<tx_fifo>\d+)(?:\s*)(?P<tx_frame>\d+)(?:\s*)(?P<tx_compressed>\d+)(?:\s*)(?P<tx_multicast>\d+)(?:.*)$' % (( '|'.join(self.config['interfaces']) ), greed)
             reg = re.compile(exp)
             # Match Interfaces
             for line in file:


### PR DESCRIPTION
By default this collector does greedy matching of interface names, that is, matching eth0 eth1 eth2... when 'eth' is a defined interface.

In our environment this results in collecting a lot of data that we are not interested in as many servers now have a lot of unused interfaces.

Implemented a greedy option so that the interface name matching becomes explicit. The default behavior does not change, but now there is an option for collecting data on only interfaces we care about.
