### PR TITLE
Switches debian build to use CDBS (Commond debian build system)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Rob Smith <kormoc@gmail.com>
 Homepage: https://github.com/BrightcoveOS/Diamond
 Vcs-Git: git://github.com/BrightcoveOS/Diamond.git
 Vcs-Browser: https://github.com/BrightcoveOS/Diamond
-Build-Depends: debhelper (>= 7), python (>= 2.4), python-support, python-mock, python-configobj
+Build-Depends: debhelper (>= 7), python (>= 2.4), python-support, python-mock, python-configobj, cdbs
 Standards-Version: 3.9.1
 
 Package: diamond

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,11 @@
 #!/usr/bin/make -f
+# -*- makefile -*-
 
-%:
-	dh $@
+DEB_PYTHON_SYSTEM := pysupport
+
+include /usr/share/cdbs/1/rules/debhelper.mk
+include /usr/share/cdbs/1/class/python-distutils.mk
+
+clean::
+	rm -rf build build-stamp configure-stamp build/ MANIFEST
+	dh_clean


### PR DESCRIPTION
CDBS seems to work more compatibly when building on launchpad/ubuntu. There is probably a way of fixing debhelper/dh under ubuntu, but this seems to work just fine
