### PR TITLE
removed license str from netscalersnmp collector

### DIFF
--- a/src/collectors/netscalersnmp/netscalersnmp.py
+++ b/src/collectors/netscalersnmp/netscalersnmp.py
@@ -2,22 +2,6 @@
 SNMPCollector for Netscaler Metrics
 """
 
-# Copyright (C) 2011 Brightcove, Inc. All Rights Reserved. No use,
-# copying or distribution of this work may be made except in
-# accordance with a valid license agreement from Brightcove, Inc. This
-# notice must be included on all copies, modifications and derivatives
-# of this work.
-#
-# Brightcove, Inc MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE
-# SUITABILITY OF THE SOFTWARE, EITHER EXPRESS OR IMPLIED, INCLUDING
-# BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT. Brightcove
-# SHALL NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT
-# OF USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
-# DERIVATIVES.
-#
-# "Brightcove" is a trademark of Brightcove, Inc.
-
 import sys
 import os
 import time


### PR DESCRIPTION
no need for the license anymore. removed it.
