### PR TITLE
don't use empty prefix.

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -178,7 +178,10 @@ class Collector(object):
 
         hostname = self.get_hostname()
         if hostname is not None:
-            prefix = prefix + "." + hostname
+            if prefix:
+                prefix = ".".join((prefix, hostname))
+            else:
+                prefix = hostname
 
         # if there is a suffix, add after the hostname
         if suffix:


### PR DESCRIPTION
this prevent a bug when a metric name starts with a dot character. which does not work with most version of graphite.

in 0.9.9, metric name that starts with a dot are ignored, in 0.9.10 carbon tries to write the metric relative to / instead of the storage dir..
that was just fixed in carbon trunk and 0.9.x branch last week
