### PR TITLE
Fix distribution check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ else:
     if platform.dist()[0] == 'Ubuntu':
         data_files.append(('/etc/init',
                            ['debian/upstart/diamond.conf']))
-    if platform.dist()[0] == 'centos' or 'redhat':
+    if platform.dist()[0] in ['centos', 'redhat']:
         data_files.append(('/etc/init.d',
                            ['bin/init.d/diamond']))
         data_files.append(('/var/log/diamond',


### PR DESCRIPTION
Trying to build a Debian package, resulted in the following error:

"error: can't copy 'rpm/upstart/diamond.conf': doesn't exist or not a regular file"
