### PR TITLE
simplify byte_unit conversion into a list

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -67,10 +67,7 @@ class Collector(object):
 
         # Handle some config file changes transparently
         if isinstance(self.config['byte_unit'], basestring):
-            units = self.config['byte_unit'].split()
-            self.config['byte_unit'] = []
-            for unit in units:
-                self.config['byte_unit'].append(unit)
+            self.config['byte_unit'] = self.config['byte_unit'].split()
 
     def get_default_config_help(self):
         """


### PR DESCRIPTION
this is very weird.

using the old way it used to turn the string into a list, see:

https://microsigns.s3.amazonaws.com/screenrecording.mov?AWSAccessKeyId=AKIAJTZQP42DGDUEHZGA&Expires=1347383719&Signature=81Ebk5ZEkV8n2Bj3XI2fRQROIys%3D
