### PR TITLE
Added handler flush() functionality

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -275,3 +275,8 @@ class Collector(object):
         except Exception:
             # Log Error
             self.log.error(traceback.format_exc())
+        finally:
+            # After collector run, invoke a flush
+            # method on each handler. 
+            for handler in self.handlers:
+                handler.flush()

--- a/src/diamond/handler/Handler.py
+++ b/src/diamond/handler/Handler.py
@@ -26,3 +26,11 @@ class Handler(object):
         Should be overridden in subclasses
         """
         raise NotImplementedError
+
+    def flush(self):
+        """
+        Flush metrics
+
+        Optional: Should be overridden in subclasses
+        """
+        pass


### PR DESCRIPTION
Use Case:
When batching requests to save on RPC calls to a remote system, the pattern used is to append metrics to an array. Once the array meets the batch size, send the request. Issues arise when the collector script terminates there may be items still in the array that have not been sent because they have not reached the batch size.

To resolve this, I have added a finally method to the collector run to invoke 'flush()' on each handler once a collector script has finished it's run. I have also added a default 'flush()' method on the Handler base class that can be overridden by the subclasses. Therefore handlers can choose to use the flush logic in their class.
