### PR TITLE
Correction to nagios.py to allow sudo to be disabled in conf

### DIFF
--- a/src/collectors/nagios/nagios.py
+++ b/src/collectors/nagios/nagios.py
@@ -77,7 +77,7 @@ class NagiosStatsCollector(diamond.collector.Collector):
                    '--data', ",".join(self.config['vars']),
                    '--mrtg']
 
-        if self.config['use_sudo']:
+        if self.config['use_sudo'] == 'True':
             command.insert(0, self.config['sudo_cmd'])
 
         p = subprocess.Popen(command,


### PR DESCRIPTION
The way the check was originally written it would alway be true and would use sudo. 
