### PR TITLE
add a SentryHandler that use Raven to send error when metric are too low...

### DIFF
--- a/src/diamond/handler/sentry.py
+++ b/src/diamond/handler/sentry.py
@@ -4,6 +4,9 @@
 Diamond handler that check if values are too high or too low, if so send an
 alert to a Sentry server
 
+This handler requires the Python module Raven:
+http://raven.readthedocs.org/en/latest/index.html
+
 To work this handler need a similar configuration:
 
 [[SentryHandler]]


### PR DESCRIPTION
... or too high

Sentry: http://getsentry.com/welcome/  is a realtime event logging and aggregation platform. At its core it specializes in monitoring errors and extracting all the information needed to do a proper post-mortem without any of the hassle of the standard user feedback loop.

This a Diamond handler that send message to sentry if some metrics are too low or too high. such as:
- free memory
- load average
- free disk space

Diamond can still be used to send metrics to a graphite server and alert sentry as well.

Sentry can be used to receive operating system errors, not just apps errors.
