### PR TITLE
Allow network metrics to push floats

### DIFF
--- a/src/collectors/network/network.py
+++ b/src/collectors/network/network.py
@@ -136,7 +136,7 @@ class NetworkCollector(diamond.collector.Collector):
                     for u in self.config['byte_unit']:
                         # Public Converted Metric
                         self.publish(metric_name.replace('bytes', u),
-                                     convertor.get(unit=u))
+                                     convertor.get(unit=u), 2)
                 else:
                     # Publish Metric Derivative
                     self.publish(metric_name, metric_value)


### PR DESCRIPTION
All network metrics are pushed as ints. This is problematic when you're collecting megabits or higher. This simple change pushed floats for anything passed by the config file for "byte_unit".
