### PR TITLE
Issue 152 unsupported operand type for sector_size in DiskUsageCollector

### DIFF
--- a/src/collectors/diskusage/diskusage.py
+++ b/src/collectors/diskusage/diskusage.py
@@ -119,12 +119,12 @@ class DiskUsageCollector(diamond.collector.Collector):
                         'reads': disks[disk].read_count,
                         'reads_merged': 0,
                         'reads_sectors': (disks[disk].read_bytes
-                                          / self.config['sector_size']),
+                                          / int(self.config['sector_size'])),
                         'reads_milliseconds': disks[disk].read_time,
                         'writes': disks[disk].write_count,
                         'writes_merged': 0,
                         'writes_sectors': (disks[disk].write_bytes
-                                           / self.config['sector_size']),
+                                           / int(self.config['sector_size'])),
                         'writes_milliseconds': disks[disk].write_time,
                         'io_in_progress': 0,
                         'io_milliseconds':
@@ -166,7 +166,7 @@ class DiskUsageCollector(diamond.collector.Collector):
 
                     if key.endswith('sectors'):
                         key = key.replace('sectors', unit)
-                        value /= (1024 / self.config['sector_size'])
+                        value /= (1024 / int(self.config['sector_size']))
                         value = diamond.convertor.binary.convert(value=value,
                                                                  oldUnit='kB',
                                                                  newUnit=unit)

--- a/src/collectors/diskusage/test/testdiskusage.py
+++ b/src/collectors/diskusage/test/testdiskusage.py
@@ -19,6 +19,7 @@ class TestDiskUsageCollector(CollectorTestCase):
     def setUp(self):
         config = get_collector_config('DiskUsageCollector', {
             'interval': 10,
+            'sector_size': '512',
             'byte_unit': 'kilobyte'
         })
 


### PR DESCRIPTION
Force sector_size to be an int before using it. Also force it to be set as a string value in the test config to force a failure if the conversions are done wrongly.
