### PR TITLE
add TotalAccesses metric

### DIFF
--- a/src/collectors/httpd/httpd.py
+++ b/src/collectors/httpd/httpd.py
@@ -51,7 +51,7 @@ class HttpdCollector(diamond.collector.Collector):
             service_port = 80
 
         metrics = ['ReqPerSec', 'BytesPerSec', 'BytesPerReq',
-                   'BusyWorkers', 'IdleWorkers']
+                   'BusyWorkers', 'IdleWorkers', 'Total Accesses']
 
         # Setup Connection
         connection = httplib.HTTPConnection(service_host, service_port)
@@ -64,7 +64,7 @@ class HttpdCollector(diamond.collector.Collector):
 
         response = connection.getresponse()
         data = response.read()
-        exp = re.compile('^([A-Za-z]+):\s+(.+)$')
+        exp = re.compile('^([A-Za-z ]+):\s+(.+)$')
         for line in data.split('\n'):
             if line:
                 m = exp.match(line)
@@ -73,7 +73,7 @@ class HttpdCollector(diamond.collector.Collector):
                     v = m.group(2)
                     if k in metrics:
                         # Get Metric Name
-                        metric_name = "%s" % k
+                        metric_name = "%s" % re.sub('\s+', '', k)
                         # Get Metric Value
                         metric_value = "%d" % float(v)
                         # Publish Metric

--- a/src/collectors/httpd/test/testhttpd.py
+++ b/src/collectors/httpd/test/testhttpd.py
@@ -55,6 +55,7 @@ class TestHttpdCollector(CollectorTestCase):
             self.collector.collect()
 
         self.assertPublishedMany(publish_mock, {
+            'TotalAccesses': 100,
             'ReqPerSec': 10,
             'BytesPerSec': 20480,
             'BytesPerReq': 204,
@@ -79,6 +80,7 @@ class TestHttpdCollector(CollectorTestCase):
             self.collector.collect()
 
         metrics = {
+            'TotalAccesses': 8314,
             'ReqPerSec': 0,
             'BytesPerSec': 165,
             'BytesPerReq': 5418,


### PR DESCRIPTION
ReqPerSec on the apache status page is computed simply by dividing the number
of requests by the uptime of the server.  With a long-running apache instance
this becomes a fairly uninteresting flat average over time.

If we also publish the 'Total Accesses' counter a graphite user can use
derivative(servers.foo.httpd.TotalAccesses) to get a more useful
requests-per-interval rate.
