### PR TITLE
cleanup/bugfix hostname configuration

### DIFF
--- a/conf/diamond.conf.example
+++ b/conf/diamond.conf.example
@@ -111,14 +111,13 @@ timeout = 15
 # Keep in mind, periods are seperators in graphite
 # hostname = my_custom_hostname
 
-# If you perfer to just use a different way of calculating the hostname
+# If you prefer to just use a different way of calculating the hostname
 # Uncomment and set this to one of these values:
-# fqdn_short  = Default. Similar to hostname -s
-# fqdn        = hostname output
-# fqdn_rev    = hostname in reverse (com.example.www)
-# uname_short = Similar to uname -n, but only the first part
-# uname_rev   = uname -r in reverse (com.example.www)
-# hostname_method = fqdn_short
+# hostname    = Hostname. Default. Similar to `hostname`
+# fqdn        = FQDN (domain name) with fallback to hostname. (www_example_com)
+#               Similar to `hostname --fqdn` or `hostname` if no fqdn found
+# fqdn_rev    = FQDN (see above) in reverse (com_example_www)
+# hostname_method = hostname
 
 # Path Prefix and Suffix
 # you can use one or both to craft the path where you want to put metrics

--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -29,21 +29,14 @@ def get_hostname(config):
     if 'hostname' in config:
         return config['hostname']
     if ('hostname_method' not in config
-        or config['hostname_method'] == 'fqdn_short'):
-        return socket.getfqdn().split('.')[0]
+        or config['hostname_method'] == 'hostname'):
+        return socket.gethostname()
     if config['hostname_method'] == 'fqdn':
         return socket.getfqdn().replace('.', '_')
     if config['hostname_method'] == 'fqdn_rev':
         hostname = socket.getfqdn().split('.')
         hostname.reverse()
-        hostname = '.'.join(hostname)
-        return hostname
-    if config['hostname_method'] == 'uname_short':
-        return os.uname()[1].split('.')[0]
-    if config['hostname_method'] == 'uname_rev':
-        hostname = os.uname()[1].split('.')
-        hostname.reverse()
-        hostname = '.'.join(hostname)
+        hostname = '_'.join(hostname)
         return hostname
     if config['hostname_method'].lower() == 'none':
         return None


### PR DESCRIPTION
the commit message should say it all, but for more info:
I was debugging an issue where my hostname would show up as `localhost`, my hostname_method is fqdn_short (default.), and found a bunch of issues with our hostname implementation

```
[dieter@dfvimeostatsd1 ~]$ cat /etc/sysconfig/network
HOSTNAME=dfvimeostatsd1
NETWORKING=yes
GATEWAY=10.90.128.1
[dieter@dfvimeostatsd1 ~]$ cat /etc/hosts
127.0.0.1        dfvimeostatsd1 localhost localhost.localdomain localhost4 localhost4.localdomain4
[dieter@dfvimeostatsd1 ~]$ hostname
dfvimeostatsd1
[dieter@dfvimeostatsd1 ~]$ hostname -s
dfvimeostatsd1
[dieter@dfvimeostatsd1 ~]$ hostname -f
dfvimeostatsd1
[dieter@dfvimeostatsd1 ~]$ hostname --fqdn
dfvimeostatsd1
[dieter@dfvimeostatsd1 ~]$ hostname --all-fqdns
dfvimeostatsd1.df.vimeows.com 
[dieter@dfvimeostatsd1 ~]$ hostname --domain
[dieter@dfvimeostatsd1 ~]$ hostname --alias
localhost localhost.localdomain localhost4 localhost4.localdomain4
[dieter@dfvimeostatsd1 ~]$ python2
Python 2.6.6 (r266:84292, Sep 11 2012, 08:34:23) 
[GCC 4.4.6 20120305 (Red Hat 4.4.6-4)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import socket
>>> import os
>>> socket.getfqdn()
'localhost.localdomain'
>>> socket.gethostbyaddr('127.0.0.1')
('dfvimeostatsd1', ['localhost', 'localhost.localdomain', 'localhost4', 'localhost4.localdomain4'], ['127.0.0.1'])
>>> socket.gethostname()
'dfvimeostatsd1'
>>> os.uname()
('Linux', 'dfvimeostatsd1', '2.6.32-279.9.1.el6.x86_64', '#1 SMP Tue Sep 25 21:43:11 UTC 2012', 'x86_64')
```
