### PR TITLE
Set up tox to run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ version.txt
 src/diamond/version.py
 .idea
 src/*.egg-info
+.tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = py27,pep8
+
+[testenv]
+deps = pyutmp
+       pyrabbit
+	   mock
+
+setenv = VIRTUAL_ENV={envdir}
+commands = {toxinidir}/test.py
+sitepackages = True
+
+[testenv:pep8]
+deps = pep8==1.1
+commands = pep8 --repeat --show-source src setup.py bin test.py
+
+[testenv:venv]
+commands = {posargs}


### PR DESCRIPTION
Configure tox to install some of the test dependencies
before running the tests.

Signed-off-by: Doug Hellmann doug.hellmann@dreamhost.com
