### PR TITLE
collectors/mongodb: Handle long typed values

### DIFF
--- a/src/collectors/mongodb/mongodb.py
+++ b/src/collectors/mongodb/mongodb.py
@@ -85,3 +85,5 @@ class MongoDBCollector(diamond.collector.Collector):
                 self._publish_metrics(keys, new_key, value)
         elif isinstance(value, int) or isinstance(value, float):
             self.publish('.'.join(keys), value)
+        elif isinstance(value, long):
+            self.publish('.'.join(keys), float(value))

--- a/src/collectors/mongodb/test/testmongodb.py
+++ b/src/collectors/mongodb/test/testmongodb.py
@@ -59,6 +59,22 @@ class TestMongoDBCollector(CollectorTestCase):
                            defaultpath=self.collector.config['path'])
         self.assertPublishedMany(publish_mock, metrics)
 
+    @patch('pymongo.Connection')
+    @patch.object(Collector, 'publish')
+    def test_should_publish_stats_with_long_type(self,
+                                                 publish_mock,
+                                                 connector_mock):
+        data = {'more_keys': long(1), 'key': 2, 'string': 'str'}
+        self._annotate_connection(connector_mock, data)
+
+        self.collector.collect()
+
+        self.connection.db.command.assert_called_once_with('serverStatus')
+        self.assertPublishedMany(publish_mock, {
+            'more_keys': 1,
+            'key': 2
+        })
+
     def _annotate_connection(self, connector_mock, data):
         connector_mock.return_value = self.connection
         self.connection.db.command.return_value = data


### PR DESCRIPTION
After upgrading our MongoDB version to 2.2, I noticed that some values are no longer being published. It appears that with the new version of MongoDB, `serverStatus` will return some value types as `long` types. For example, here is a snippet of the result of a `serverStatus` command using MongoDB shell version 2.2.0:

``` javascript
    "locks" : {
        "." : {
            "timeLockedMicros" : {
                "R" : NumberLong(200613),
                "W" : NumberLong(113698)
            },
            "timeAcquiringMicros" : {
                "R" : NumberLong(226017),
                "W" : NumberLong(26966)
            }
        },
        "admin" : {
            "timeLockedMicros" : {

            },
            "timeAcquiringMicros" : {

            }
        },
        "local" : {
            "timeLockedMicros" : {
                "r" : NumberLong(3922),
                "w" : NumberLong(14)
            },
            "timeAcquiringMicros" : {
                "r" : NumberLong(941),
                "w" : NumberLong(76)
            }
        }
    }
```

The collector checks that the type is `float` or `int`, so no longer publishes all values.

This commit checks if the type is `long` and, if so, converts the value to a `float` before publishing it. It is possible to have an overflow in this conversion, but that should be practically impossible because the `long`s represent microseconds, whose value should not exceed that of the range of `float`.
