### PR TITLE
generate version.txt file if not available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,11 +52,14 @@ else:
 
 
 def get_version():
-    f = open('version.txt')
+    try:
+        f = open('version.txt')
+    except IOError:
+        os.system("./version.sh > version.txt")
+        f = open('version.txt')
     version = ''.join(f.readlines()).rstrip()
     f.close()
     return version
-
 
 def pkgPath(root, path, rpath="/"):
     global data_files


### PR DESCRIPTION
I'm using http://saltstack.org to deploy my servers.
I used to just pip install the git repository, but since oct 24 I can't. `setup.py` requires `version.txt` which is generated from `version.sh`.

my fix is ugly, but this fix make Diamond installable trough setup.py install.
