### PR TITLE
Remove superfluous logging call in ceph collector

### DIFF
--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -133,7 +133,6 @@ class CephCollector(diamond.collector.Collector):
             stats,
             prefix=counter_prefix,
         ):
-            self.log.debug('%s = %s', stat_name, stat_value)
             self.publish(stat_name, stat_value)
 
     def collect(self):


### PR DESCRIPTION
We don't need to log everything being emitted, since
it just slows down the process.

Change-Id: I63c6dc30d002dc0ab127648e53daab066763d6a6
Signed-off-by: Doug Hellmann doug.hellmann@dreamhost.com
