### PR TITLE
Update StatsD handler to work with the latest StatsD

### DIFF
--- a/src/diamond/handler/stats_d.py
+++ b/src/diamond/handler/stats_d.py
@@ -73,12 +73,8 @@ class StatsdHandler(Handler):
         # to work with the statsd module's view of the world.
         # It will get re-joined by the python-statsd module.
         (prefix, name) = metric.path.rsplit(".", 1)
-        logging.debug("Sending {0} {1} {2}|r".format(name,
-                                                     metric.value,
-                                                     metric.timestamp))
-        statsd.Raw(prefix, self.connection).send(name,
-                                                 metric.value,
-                                                 metric.timestamp)
+        logging.debug("Sending {0} {1}|g".format(name, metric.value))
+        statsd.Gauge(prefix, self.connection).send(name, metric.value)
 
     def _connect(self):
         """


### PR DESCRIPTION
The Raw data type is no longer used and has since been replaced with the Gauge type. The Gauge type doesn't take timestamps, statsd takes care of the "now" timestamp when it receives the data.
