### PR TITLE
Added support for floats to userscripts

### DIFF
--- a/src/collectors/userscripts/test/fixtures/example.sh
+++ b/src/collectors/userscripts/test/fixtures/example.sh
@@ -2,3 +2,4 @@
 
 echo "example.1 42"
 echo "example.2 24"
+echo "example.3 12.1212"

--- a/src/collectors/userscripts/test/testuserscripts.py
+++ b/src/collectors/userscripts/test/testuserscripts.py
@@ -31,6 +31,7 @@ class TestUserScriptsCollector(CollectorTestCase):
         metrics = {
             'example.1': 42,
             'example.2': 24,
+            'example.3': 12.1212,
         }
 
         self.setDocExample(collector=self.collector.__class__.__name__,

--- a/src/collectors/userscripts/userscripts.py
+++ b/src/collectors/userscripts/userscripts.py
@@ -45,6 +45,7 @@ class UserScriptsCollector(diamond.collector.Collector):
             'path':         '.',
             'scripts_path': '/etc/diamond/user_scripts/',
             'method':       'Threaded',
+            'floatprecision': 4,
         })
         return config
 
@@ -61,4 +62,7 @@ class UserScriptsCollector(diamond.collector.Collector):
                 continue
             for line in out.split('\n'):
                 name, value = line.split()
-                self.publish(name, value)
+                floatprecision = 0
+                if "." in value:
+                    floatprecision = self.config['floatprecision']
+                self.publish(name, value, floatprecision)


### PR DESCRIPTION
I use a lot of logster, with relatively high precision floats. After moving my logster execution from cron to userscripts in diamond, I found that I only got ints submitted to graphite. I've added the precision of floats submitted from userscripts as a configurable parameter if a period is found in the metric value.
