### PR TITLE
Added a collector for beanstalkd

### DIFF
--- a/src/collectors/beanstalkd/beanstalkd.py
+++ b/src/collectors/beanstalkd/beanstalkd.py
@@ -1,0 +1,75 @@
+# coding=utf-8
+
+"""
+Collects the following from beanstalkd:
+    - Server statistics via the 'stats' command
+    - Per tube statistics via the 'stats-tube' command
+
+#### Dependencies
+
+ * beanstalkc
+
+"""
+
+import diamond.collector
+
+try:
+    import beanstalkc
+except ImportError:
+    beanstalkc = None
+
+class BeanstalkdCollector(diamond.collector.Collector):
+    def get_default_config_help(self):
+        config_help = super(BeanstalkdCollector, self).get_default_config_help()
+        config_help.update({
+            'host': 'Hostname',
+            'port': 'Port',
+        })
+        return config_help
+
+    def get_default_config(self):
+        """
+        Returns the default collector settings
+        """
+        config = super(BeanstalkdCollector, self).get_default_config()
+        config.update({
+            'path':     'beanstalkd',
+            'host':     'localhost',
+            'port':     11300,
+        })
+        return config
+
+    def _get_stats(self):
+        stats = {}
+        try:
+            connection = beanstalkc.Connection(self.config['host'],
+                                               self.config['port'])
+        except beanstalkc.BeanstalkcException, e:
+            self.log.error("Couldn't connect to beanstalkd: %s", e)
+            return {}
+
+        stats['instance'] = connection.stats()
+        stats['tubes'] = []
+
+        for tube in connection.tubes():
+            tube_stats = connection.stats_tube(tube)
+            stats['tubes'].append(tube_stats)
+
+        return stats
+
+    def collect(self):
+        if beanstalkc is None:
+            self.log.error('Unable to import beanstalkc')
+            return {}
+
+        info = self._get_stats()
+
+        for stat, value in info['instance'].items():
+            if stat != 'version':
+                self.publish(stat, value)
+
+        for tube_stats in info['tubes']:
+            tube = tube_stats['name']
+            for stat, value in tube_stats.items():
+                if stat != 'name':
+                    self.publish('tubes.%s.%s' % (tube, stat), value)

--- a/src/collectors/beanstalkd/test/testbeanstalkd.py
+++ b/src/collectors/beanstalkd/test/testbeanstalkd.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python
+# coding=utf-8
+################################################################################
+
+from __future__ import with_statement
+
+from test import CollectorTestCase
+from test import get_collector_config
+from test import unittest
+from mock import Mock
+from mock import patch
+
+from diamond.collector import Collector
+from beanstalkd import BeanstalkdCollector
+
+################################################################################
+
+
+class TestBeanstalkdCollector(CollectorTestCase):
+    def setUp(self):
+        config = get_collector_config('BeanstalkdCollector', {
+            'host': 'localhost',
+            'port': 11300,
+        })
+
+        self.collector = BeanstalkdCollector(config, None)
+
+    @patch.object(Collector, 'publish')
+    def test_should_work_with_real_data(self, publish_mock):
+        stats = {
+            'instance': {
+                'current-connections': 10,
+                'max-job-size': 65535,
+                'cmd-release': 0,
+                'cmd-reserve': 4386,
+                'pid': 23703,
+                'cmd-bury': 0,
+                'current-producers': 0,
+                'total-jobs': 4331,
+                'current-jobs-ready': 0,
+                'cmd-peek-buried': 0,
+                'current-tubes': 7,
+                'current-jobs-delayed': 0,
+                'uptime': 182954,
+                'cmd-watch': 55,
+                'job-timeouts': 0,
+                'cmd-stats': 1,
+                'rusage-stime': 295.970497,
+                'current-jobs-reserved': 0,
+                'current-jobs-buried': 0,
+                'cmd-reserve-with-timeout': 0,
+                'cmd-put': 4331,
+                'cmd-pause-tube': 0,
+                'cmd-list-tubes-watched': 0,
+                'cmd-list-tubes': 0,
+                'current-workers': 9,
+                'cmd-list-tube-used': 0,
+                'cmd-ignore': 0,
+                'binlog-records-migrated': 0,
+                'current-waiting': 9,
+                'cmd-peek': 0,
+                'cmd-peek-ready': 0,
+                'cmd-peek-delayed': 0,
+                'cmd-touch': 0,
+                'binlog-oldest-index': 0,
+                'binlog-current-index': 0,
+                'cmd-use': 4321,
+                'total-connections': 4387,
+                'cmd-delete': 4331,
+                'binlog-max-size': 10485760,
+                'cmd-stats-job': 0,
+                'rusage-utime': 125.92787,
+                'cmd-stats-tube': 0,
+                'binlog-records-written': 0,
+                'cmd-kick': 0,
+                'current-jobs-urgent': 0,
+            },
+            'tubes': [
+                {
+                    'current-jobs-delayed': 0,
+                    'pause': 0,
+                    'name': 'default',
+                    'cmd-pause-tube': 0,
+                    'current-jobs-buried': 0,
+                    'cmd-delete': 10,
+                    'pause-time-left': 0,
+                    'current-waiting': 9,
+                    'current-jobs-ready': 0,
+                    'total-jobs': 10,
+                    'current-watching': 10,
+                    'current-jobs-reserved': 0,
+                    'current-using': 10,
+                    'current-jobs-urgent': 0,
+                }
+             ]
+        }
+
+        with patch.object(BeanstalkdCollector,
+                          '_get_stats',
+                          Mock(return_value=stats)):
+            self.collector.collect()
+
+        metrics = {
+            'current-connections': 10,
+            'max-job-size': 65535,
+            'cmd-release': 0,
+            'cmd-reserve': 4386,
+            'pid': 23703,
+            'cmd-bury': 0,
+            'current-producers': 0,
+            'total-jobs': 4331,
+            'current-jobs-ready': 0,
+            'cmd-peek-buried': 0,
+            'current-tubes': 7,
+            'current-jobs-delayed': 0,
+            'uptime': 182954,
+            'cmd-watch': 55,
+            'job-timeouts': 0,
+            'cmd-stats': 1,
+            'rusage-stime': 295.970497,
+            'current-jobs-reserved': 0,
+            'current-jobs-buried': 0,
+            'cmd-reserve-with-timeout': 0,
+            'cmd-put': 4331,
+            'cmd-pause-tube': 0,
+            'cmd-list-tubes-watched': 0,
+            'cmd-list-tubes': 0,
+            'current-workers': 9,
+            'cmd-list-tube-used': 0,
+            'cmd-ignore': 0,
+            'binlog-records-migrated': 0,
+            'current-waiting': 9,
+            'cmd-peek': 0,
+            'cmd-peek-ready': 0,
+            'cmd-peek-delayed': 0,
+            'cmd-touch': 0,
+            'binlog-oldest-index': 0,
+            'binlog-current-index': 0,
+            'cmd-use': 4321,
+            'total-connections': 4387,
+            'cmd-delete': 4331,
+            'binlog-max-size': 10485760,
+            'cmd-stats-job': 0,
+            'rusage-utime': 125.92787,
+            'cmd-stats-tube': 0,
+            'binlog-records-written': 0,
+            'cmd-kick': 0,
+            'current-jobs-urgent': 0,
+            'tubes.default.current-jobs-delayed': 0,
+            'tubes.default.pause': 0,
+            'tubes.default.cmd-pause-tube': 0,
+            'tubes.default.current-jobs-buried': 0,
+            'tubes.default.cmd-delete': 10,
+            'tubes.default.pause-time-left': 0,
+            'tubes.default.current-waiting': 9,
+            'tubes.default.current-jobs-ready': 0,
+            'tubes.default.total-jobs': 10,
+            'tubes.default.current-watching': 10,
+            'tubes.default.current-jobs-reserved': 0,
+            'tubes.default.current-using': 10,
+            'tubes.default.current-jobs-urgent': 0,
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+################################################################################
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I added a general purpose collector to retrieve statistics from beanstalkd (simple, fast work queue). It will collect general statistics for the process itself as well as statistics for each tube that beanstalk knows about.
