### PR TITLE
Fix for bad usage of _send in graphitepickle.py

### DIFF
--- a/src/diamond/handler/graphitepickle.py
+++ b/src/diamond/handler/graphitepickle.py
@@ -59,9 +59,9 @@ class GraphitePickleHandler(GraphiteHandler):
             self.log.debug("GraphitePickleHandler: Sending batch size: %d",
                            self.batch_size)
             # Pickle the batch of metrics
-            data = self._pickle_batch()
+            self.metrics = [ self._pickle_batch() ]
             # Send pickled batch
-            self._send(data)
+            self._send()
             # Clear Batch
             self.batch = []
 


### PR DESCRIPTION
When trying to use the current version of the GraphitePickleHandler, it errors out when trying to send, due to bad usage of the Handler._send method.

Error message:

``` python
[2012-12-05 01:31:37,127] [Thread-12] Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/diamond/handler/Handler.py", line 30, in _process
    self.process(metric)
  File "/usr/lib/python2.6/site-packages/diamond/handler/graphitepickle.py", line 64, in process
    self._send(data)
TypeError: _send() takes exactly 1 argument (2 given)
```

This change, slightly modifies the handler, assigning the pickled/packed content into the self.metrics array and then calling self._send with no extra arguments.
