### PR TITLE
Make debian prerm not fail if diamond is not running

### DIFF
--- a/debian/prerm
+++ b/debian/prerm
@@ -17,7 +17,7 @@ set -e
 # the debian-policy package
 
 # Stop diamond if it's running
-stop diamond
+stop diamond || true
 
 case "$1" in
     remove|upgrade|deconfigure)


### PR DESCRIPTION
It's impossible to apt-get remove diamond if it isn't running.
