### PR TITLE
Add prefix to Riemann events

### DIFF
--- a/src/diamond/handler/riemann.py
+++ b/src/diamond/handler/riemann.py
@@ -55,9 +55,11 @@ class RiemannHandler(Handler):
         Convert a metric to a dictionary representing a Riemann event.
         """
         # Riemann has a separate "host" field, so remove from the path.
-        path = metric.getCollectorPath()
-        path += '.'
-        path += metric.getMetricPath()
+        path = '%s.%s.%s' % (
+            metric.getPathPrefix(),
+            metric.getCollectorPath(),
+            metric.getMetricPath()
+        )
 
         return {
             'host': metric.host,

--- a/src/diamond/handler/test/testriemann.py
+++ b/src/diamond/handler/test/testriemann.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python
+# coding=utf-8
+################################################################################
+
+from __future__ import with_statement
+
+from test import unittest
+import configobj
+
+from diamond.handler.riemann import RiemannHandler
+from diamond.metric import Metric
+
+class TestRiemannHandler(unittest.TestCase):
+    def test_metric_to_riemann_event(self):
+        config = configobj.ConfigObj()
+        config['host'] = 'localhost'
+        config['port'] = 5555
+
+        handler = RiemannHandler(config)
+        metric = Metric('servers.com.example.www.cpu.total.idle',
+                        0,
+                        timestamp=1234567,
+                        host='com.example.www')
+
+        event = handler._metric_to_riemann_event(metric)
+
+        self.assertEqual(event, {
+            'host': 'com.example.www',
+            'service': 'servers.cpu.total.idle',
+            'time': 1234567,
+            'metric': 0.0,
+        })
+
+
+


### PR DESCRIPTION
Otherwise, in Riemann, there is no way to differentiate Diamond events from other events.
