### PR TITLE
Fixing double release of locks

### DIFF
--- a/src/diamond/handler/Handler.py
+++ b/src/diamond/handler/Handler.py
@@ -18,7 +18,7 @@ class Handler(object):
         # Initialize Data
         self.config = config
         # Initialize Lock
-        self.lock = threading.Condition(threading.Lock())
+        self.lock = threading.Lock()
 
     def _process(self, metric):
         """
@@ -31,9 +31,10 @@ class Handler(object):
                 self.process(metric)
                 self.lock.release()
             except Exception:
-                    self.log.error(traceback.format_exc())
+                self.log.error(traceback.format_exc())
         finally:
-            self.lock.release()
+            if self.lock.locked():
+                self.lock.release()
             self.log.debug("Unlocked Handler %s" % (self))
 
     def process(self, metric):


### PR DESCRIPTION
There are currently a double release of locks in Handler.py, that causes an exception to be fired, and thus no more than the first metric of the batch is sent to the destination.

This pull requests changes to a simple lock, since we arent using any of the added functionality of threading.Condition, and checks the state of the lock in the finally block, before trying to release it a second time.
