### PR TITLE
Fixed rabbitmq vhosts

### DIFF
--- a/src/collectors/rabbitmq/rabbitmq.py
+++ b/src/collectors/rabbitmq/rabbitmq.py
@@ -53,8 +53,8 @@ class RabbitMQCollector(diamond.collector.Collector):
                                          self.config['user'],
                                          self.config['password'])
 
-            for vhost in client.get_vhosts():
-                for queue in client.get_queues(vhost=vhost):
+            for vhost in client.get_all_vhosts():
+                for queue in client.get_queues(vhost=vhost['name']):
                     for key in queue:
                         name = '{0}.{1}'.format('queues', queue['name'])
                         self._publish_metrics(name, [], key, queue)


### PR DESCRIPTION
I some how copied wrong stuff in my last PR, sorry !
Also, metric names don't contain vhost name.
If two vhosts have the queues with the same name, the metrics will collide.
