### PR TITLE
Don't write to stderr when daemonized

### DIFF
--- a/src/diamond/scheduler.py
+++ b/src/diamond/scheduler.py
@@ -73,6 +73,7 @@ import os
 import sys
 import sched
 import time
+import logging
 import traceback
 import weakref
 
@@ -88,6 +89,7 @@ class Scheduler:
 
     def __init__(self):
         self.running = True
+	self.log = logging.getLogger('diamond')
         self.sched = sched.scheduler(time.time, self.__delayfunc)
 
     def __delayfunc(self, delay):
@@ -278,10 +280,8 @@ class Scheduler:
             try:
                 self.sched.run()
             except Exception, x:
-                print >> sys.stderr, "ERROR DURING SCHEDULER EXECUTION", x
-                print >> sys.stderr, "".join(
-                    traceback.format_exception(*sys.exc_info()))
-                print >> sys.stderr, "-" * 20
+                self.log.error("ERROR DURING SCHEDULER EXECUTION %s \n %s", x,
+                        "".join( traceback.format_exception(*sys.exc_info())))
             # queue is empty; sleep a short while before checking again
             if self.running:
                 time.sleep(5)
@@ -296,6 +296,7 @@ class Task:
         self.action = action
         self.args = args
         self.kw = kw
+	self.log = logging.getLogger('diamond')
 
     def __call__(self, schedulerref):
         """Execute the task action in the scheduler's thread."""
@@ -316,10 +317,8 @@ class Task:
 
     def handle_exception(self, exc):
         """Handle any exception that occured during task execution."""
-        print >> sys.stderr, "ERROR DURING TASK EXECUTION", exc
-        print >> sys.stderr, "".join(traceback.format_exception(
-            *sys.exc_info()))
-        print >> sys.stderr, "-" * 20
+        self.log.error("ERROR DURING TASK EXECUTION %s \n %s", exc,
+                "".join(traceback.format_exception( *sys.exc_info())))
 
 
 class SingleTask(Task):


### PR DESCRIPTION
I haven't digged into this any deeper but is seems like the scheduler thread dies when it encounters an exceptions and tries to write to stderr (fd closed)

If I stop carbon Diamond will also stop trying to send and collecting data.
