### PR TITLE
Bugfix: new handlers not detected on reload.

### DIFF
--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -55,12 +55,12 @@ class Server(object):
                 configname = os.path.basename(filename)
                 handlername = configname.split('.')[0]
                 if handlername not in self.config['handlers']:
-                    self.config['handlers'][handlername] = configobj.ConfigObj()
+                    config['handlers'][handlername] = configobj.ConfigObj()
 
                 configfile = os.path.join(
                     config['server']['handlers_config_path'],
                     configname)
-                self.config['handlers'][handlername].merge(
+                config['handlers'][handlername].merge(
                     configobj.ConfigObj(configfile))
 
         self.config = config


### PR DESCRIPTION
Fixed a bug whereby new handlers added during runtime were not saved into the config tree.
