### PR TITLE
Fix mysql collector

### DIFF
--- a/src/collectors/mysql/mysql.py
+++ b/src/collectors/mysql/mysql.py
@@ -10,7 +10,13 @@ GRANT SELECT, REPLICATION CLIENT on *.* TO 'user'@'hostname' IDENTIFIED BY
 'password';
 ```
 
- * For innodb engine status
+ * For innodb engine status 
+```
+GRANT SUPER ON *.* TO 'user'@'hostname' IDENTIFIED BY
+'password';
+```
+
+ * For innodb engine status on MySQL versions 5.1.24+
 ```
 GRANT PROCESS ON *.* TO 'user'@'hostname' IDENTIFIED BY
 'password';


### PR DESCRIPTION
The MySQL collector will send duplicate metrics when using the publish option e.g.

publish = Com_delete Com_insert

```
[2013-01-22 10:56:17,950] [Thread-1] servers.diamond-test.mysql.Com_delete 0 1358848577
[2013-01-22 10:56:17,950] [Thread-1] servers.diamond-test.mysql.Com_insert 0 1358848577
[2013-01-22 10:56:17,950] [Thread-1] servers.diamond-test.mysql.Com_delete 0 1358848577
[2013-01-22 10:56:17,950] [Thread-1] servers.diamond-test.mysql.Com_insert 0 1358848577
[2013-01-22 10:56:17,951] [Thread-1] servers.diamond-test.mysql.Com_delete 0 1358848577
...
```

Fixed a small typo to get the innodb option to work ref:
https://github.com/BrightcoveOS/Diamond/blob/master/src/collectors/mysql/mysql.py#L352

I think the least privilege for running show engine innodb status is process.
