### PR TITLE
Multi instance support for RedisCollector

### DIFF
--- a/src/collectors/redisstat/test/testredisstat.py
+++ b/src/collectors/redisstat/test/testredisstat.py
@@ -190,7 +190,7 @@ class TestRedisCollector(CollectorTestCase):
 
         testcases = {
             'default': {
-                'config': {},
+                'config': {},  # test default settings
                 'calls': [call('6379', 'localhost', 6379)],
             },
             'host_set': {
@@ -206,24 +206,41 @@ class TestRedisCollector(CollectorTestCase):
                 'calls': [call('5005', 'megahost', 5005)],
             },
             'instance_1_host': {
-                'config': {'instances': ['nick myhost']},
+                'config': {'instances': ['nick@myhost']},
                 'calls': [call('nick', 'myhost', 6379)],
             },
             'instance_1_port': {
-                'config': {'instances': ['nick :9191']},
+                'config': {'instances': ['nick@:9191']},
                 'calls': [call('nick', 'localhost', 9191)],
             },
             'instance_1_hostport': {
-                'config': {'instances': ['nick host1:8765']},
+                'config': {'instances': ['nick@host1:8765']},
                 'calls': [call('nick', 'host1', 8765)],
             },
             'instance_2': {
-                'config': {'instances': ['foo hostX', 'bar :1000']},
-                'calls': [call('foo', 'hostX', 6379), call('bar', 'localhost', 1000)],
+                'config': {'instances': ['foo@hostX', 'bar@:1000']},
+                'calls': [
+                    call('foo', 'hostX', 6379),
+                    call('bar', 'localhost', 1000)
+                ],
             },
-            'instance_3': {
-                'config': {'instances': ['foo hostX', 'bar :1000']},
-                'calls': [call('foo', 'hostX', 6379), call('bar', 'localhost', 1000)],
+            'old_and_new': {
+                'config': {
+                    'host': 'myhost',
+                    'port': 1234,
+                    'instances': [
+                        'foo@hostX',
+                        'bar@:1000',
+                        'hostonly',
+                        ':1234'
+                    ]
+                },
+                'calls': [
+                    call('foo', 'hostX', 6379),
+                    call('bar', 'localhost', 1000),
+                    call('6379', 'hostonly', 6379),
+                    call('1234', 'localhost', 1234),
+                ],
             },
         }
 
@@ -240,15 +257,25 @@ class TestRedisCollector(CollectorTestCase):
             patch_c.stop()
 
             expected_call_count = len(data['calls'])
-            self.assertEqual(mock.call_count, expected_call_count)
-            mock.assert_has_calls(data['calls'])
+            self.assertEqual(mock.call_count, expected_call_count,
+                             msg='[%s] mock.calls=%d != expected_calls=%d' %
+                             (testname, mock.call_count, expected_call_count))
+            for exp_call in data['calls']:
+                # Test expected calls 1 by 1,
+                # because self.instances is a dict (=random order)
+                mock.assert_has_calls(exp_call)
 
     @run_only_if_redis_is_available
     @patch.object(Collector, 'publish')
     def test_key_naming_when_using_instances(self, publish_mock):
 
         config_data = {
-            'instances': ['nick1 host1:1111', 'nick2 :2222', 'nick3 host3', 'bla']
+            'instances': [
+                'nick1@host1:1111',
+                'nick2@:2222',
+                'nick3@host3',
+                'bla'
+            ]
         }
         get_info_data = {
             'total_connections_received': 200,
@@ -261,13 +288,15 @@ class TestRedisCollector(CollectorTestCase):
             call('nick2.process.commands_processed', 100, 0, 'GAUGE'),
             call('nick3.process.connections_received', 200, 0, 'GAUGE'),
             call('nick3.process.commands_processed', 100, 0, 'GAUGE'),
+            call('6379.process.connections_received', 200, 0, 'GAUGE'),
+            call('6379.process.commands_processed', 100, 0, 'GAUGE'),
         ]
 
         config = get_collector_config('RedisCollector', config_data)
         collector = RedisCollector(config, None)
 
         patch_c = patch.object(RedisCollector, '_get_info',
-                                       Mock(return_value=get_info_data))
+                               Mock(return_value=get_info_data))
 
         patch_c.start()
         collector.collect()
@@ -275,8 +304,8 @@ class TestRedisCollector(CollectorTestCase):
 
         self.assertEqual(publish_mock.call_count, len(expected_calls))
         for exp_call in expected_calls:
-            # Test calls 1 by 1. Calls can come in random order, because
-            # config_data['instances'] is translated into a dict (=random order)
+            # Test expected calls 1 by 1,
+            # because self.instances is a dict (=random order)
             publish_mock.assert_has_calls(exp_call)
 
 


### PR DESCRIPTION
Re: #234

The current RedisCollector only supports harvesting 1 Redis server.

I have added:
- support for multiple servers, without breaking the old config method.
- Redis client timeout support.
- more unittests to verify not breaking the old config method.

Regards.
