### PR TITLE
Fix for ProcessMemoryCollector for python 2.4 

### DIFF
--- a/src/collectors/processmemory/processmemory.py
+++ b/src/collectors/processmemory/processmemory.py
@@ -109,8 +109,7 @@ class ProcessMemoryCollector(diamond.collector.Collector):
                 if not isinstance(proc[key], list):
                     proc[key] = [proc[key]]
                 proc[key] = [re.compile(e) for e in proc[key]]
-            selfmon = cfg.get('selfmon', 'false').strip().lower()
-            proc['selfmon'] = True if selfmon == 'true' else False
+            proc['selfmon'] = cfg.get('selfmon', '').lower() == 'true'
             self.processes[process] = proc
 
     def filter_processes(self):


### PR DESCRIPTION
I was running/testing my ProcessMemoryCollector changes on python 2.6. I just noticed that it breaks on 2.4. Rewrote the culprit:

```
proc['selfmon'] = True if selfmon == 'true' else False
```
