### PR TITLE
Use subprocess instead of commands

### DIFF
--- a/.travis.requirements.txt
+++ b/.travis.requirements.txt
@@ -7,3 +7,4 @@ redis
 beanstalkc
 bernhard
 simplejson
+kitchen

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps = pyutmp
        mock
        beanstalkc
        bernhard
+       kitchen
 
 setenv = VIRTUAL_ENV={envdir}
 commands = {toxinidir}/test.py


### PR DESCRIPTION
commands is deprecated in 2.6+ and removed in python 3.  subprocess is
the new way forward.  The very useful check_output is only in 2.7 or
newer, so use kitchen to get the newer code on older systems.
