### PR TITLE
Fix to snmpinterface - typo and updated SNMP name for 64 bit values.

### DIFF
--- a/src/collectors/ipvs/ipvs.py
+++ b/src/collectors/ipvs/ipvs.py
@@ -46,7 +46,7 @@ class IPVSCollector(diamond.collector.Collector):
             return
 
         command = [self.config['bin'], '--list',
-                   '--stats', '--numeric', '--exact']
+                   '--stats', '--numeric']
 
         if self.config['use_sudo']:
             command.insert(0, self.config['sudo_cmd'])
@@ -79,6 +79,16 @@ class IPVSCollector(diamond.collector.Collector):
 
             for metric, column in columns.iteritems():
                 metric_name = ".".join([external, backend, metric])
-                metric_value = int(row[column])
+                # metric_value = int(row[column])
+                value = row[column]
+                if (value.endswith('K')):
+                        metric_value = int(value[0:len(value)-1]) * 1024
+                elif (value.endswith('M')):
+                        metric_value = int(value[0:len(value)-1]) * 1024 * 1024
+                elif (value.endswith('G')):
+                        metric_value = int(value[0:len(value)-1]) * 1024.0 * 1024.0 * 1024.0
+                else:
+                        metric_value = float(value)
+
 
                 self.publish(metric_name, metric_value)

--- a/src/collectors/snmpinterface/snmpinterface.py
+++ b/src/collectors/snmpinterface/snmpinterface.py
@@ -74,18 +74,18 @@ class SNMPInterfaceCollector(parent_SNMPCollector):
     IF_MIB_NAME_OID = "1.3.6.1.2.1.31.1.1.1.1"
     IF_MIB_TYPE_OID = "1.3.6.1.2.1.2.2.1.3"
 
-    # A list of IF-MIB the 32bit counters to walk
+    # A list of IF-MIB 32bit counters to walk
     IF_MIB_GAUGE_OID_TABLE = {'ifInDiscards': "1.3.6.1.2.1.2.2.1.13",
                               'ifInErrors': "1.3.6.1.2.1.2.2.1.14",
                               'ifOutDiscards': "1.3.6.1.2.1.2.2.1.19",
                               'ifOutErrors': "1.3.6.1.2.1.2.2.1.20"}
 
     # A list of IF-MIB 64bit counters to talk
-    IF_MIB_COUNTER_OID_TABLE = {'ifInOctets': "1.3.6.1.2.1.31.1.1.1.6",
+    IF_MIB_COUNTER_OID_TABLE = {'ifHCInOctets': "1.3.6.1.2.1.31.1.1.1.6",
                                 'ifInUcastPkts': "1.3.6.1.2.1.31.1.1.1.7",
                                 'ifInMulticastPkts': "1.3.6.1.2.1.31.1.1.1.8",
                                 'ifInBroadcastPkts': "1.3.6.1.2.1.31.1.1.1.9",
-                                'ifOutOctets': "1.3.6.1.2.1.31.1.1.1.10",
+                                'ifHCOutOctets': "1.3.6.1.2.1.31.1.1.1.10",
                                 'ifOutUcastPkts': "1.3.6.1.2.1.31.1.1.1.11",
                                 'ifOutMulticastPkts': "1.3.6.1.2.1.31.1.1.1.12",
                                 'ifOutBroadcastPkts': "1.3.6.1.2.1.31.1.1.1.13"}
@@ -178,7 +178,7 @@ class SNMPInterfaceCollector(parent_SNMPCollector):
                 # Get Metric Name and Value
                 metricIfDescr = re.sub(r'\W', '_', ifName)
 
-                if counterName in ['ifInOctets', 'ifOutOctets']:
+                if counterName in ['ifHCInOctets', 'ifHCOutOctets']:
                     for unit in self.config['byte_unit']:
                         # Convert Metric
                         metricName = '.'.join([metricIfDescr,


### PR DESCRIPTION
snmpinterface - fix typo. fix SNMP value name to indicate 64 bit.
