### PR TITLE
Changes behaviour of diskspace.py how monitored filesystems are collected

### DIFF
--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -104,6 +104,16 @@ class DiskSpaceCollector(diamond.collector.Collector):
         Returns:
           (major, minor) -> FileSystem(device, mount_point)
         """
+        exclude_filters = self.config['exclude_filters']
+        if isinstance(exclude_filters, basestring):
+            exclude_filters = [exclude_filters]
+
+        exclude_reg = re.compile('|'.join(exclude_filters))
+
+        filesystems = []
+        for filesystem in self.config['filesystems'].split(','):
+            filesystems.append(filesystem.strip())
+
         result = {}
         if os.access('/proc/mounts', os.R_OK):
             file = open('/proc/mounts')
@@ -114,6 +124,16 @@ class DiskSpaceCollector(diamond.collector.Collector):
                     mount_point = mount[1]
                     fs_type = mount[2]
                 except (IndexError, ValueError):
+                    continue
+
+                # Skip the filesystem if it is not in the list of valid filesystems
+                if fs_type not in filesystems:
+                    self.log.debug("Ignoring %s since it is of type %s which is not in the list of filesystems." % (mount_point, fs_type))
+                    continue
+
+                # Process the filters
+                if exclude_reg.match(mount_point):
+                    self.log.debug("Ignoring %s since it is in the exclude_filter list." % mount_point)
                     continue
 
                 if (mount_point.startswith('/dev')
@@ -154,26 +174,8 @@ class DiskSpaceCollector(diamond.collector.Collector):
         return result
 
     def collect(self):
-        exclude_filters = self.config['exclude_filters']
-        if isinstance(exclude_filters, basestring):
-            exclude_filters = [exclude_filters]
-
-        exclude_reg = re.compile('|'.join(exclude_filters))
-
-        filesystems = []
-        for filesystem in self.config['filesystems'].split(','):
-            filesystems.append(filesystem.strip())
-
         labels = self.get_disk_labels()
         for key, info in self.get_file_systems().iteritems():
-        # Skip the filesystem if it is not in the list of valid filesystems
-            if info['fs_type'] not in filesystems:
-                continue
-
-        # Process the filters
-            if exclude_reg.match(info['mount_point']):
-                continue
-
             if info['device'] in labels:
                 name = labels[info['device']]
             else:

--- a/src/collectors/diskspace/test/fixtures/proc_mounts
+++ b/src/collectors/diskspace/test/fixtures/proc_mounts
@@ -10,3 +10,4 @@ none /sys/kernel/security securityfs rw,relatime 0 0
 none /dev/shm tmpfs rw,nosuid,nodev,relatime 0 0
 none /var/run tmpfs rw,nosuid,relatime,mode=755 0 0
 none /var/lock tmpfs rw,nosuid,nodev,noexec,relatime 0 0
+/etc/auto.misc /misc autofs rw,relatime,fd=6,pgrp=1171,timeout=300,minproto=5,maxproto=5,indirect 0 0


### PR DESCRIPTION
Hi,
we had a little trouble with the diskspace collector - it made a stat() call on every file system listed in /proc/mounts, which caused our auto mounter to mount all of them.
To prevent this I moved the filesystem filtering and handling of the exclude list above the stat call. Think this could be useful for others that have autofs running on their hosts.
Additionally I added a line to the mocked proc/mounts-file to test this.

Cheers
Robert
