### PR TITLE
Add Shmem to default keys for MemoryCollector

### DIFF
--- a/src/collectors/memory/memory.py
+++ b/src/collectors/memory/memory.py
@@ -27,6 +27,7 @@ _KEY_MAPPING = [
     'Active',
     'Dirty',
     'Inactive',
+    'Shmem',
     'SwapTotal',
     'SwapFree',
     'SwapCached',

--- a/src/collectors/memory/test/testmemory.py
+++ b/src/collectors/memory/test/testmemory.py
@@ -53,6 +53,7 @@ class TestMemoryCollector(CollectorTestCase):
             'Active': 10022168,
             'Dirty': 24748,
             'Inactive': 2524928,
+            'Shmem': 276,
             'SwapTotal': 262143996,
             'SwapFree': 262143996,
             'SwapCached': 0,


### PR DESCRIPTION
Useful for at least PostgreSQL and Nginx
