### PR TITLE
Chef metrics are gauge not counters

### DIFF
--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -133,7 +133,7 @@ class CephCollector(diamond.collector.Collector):
             stats,
             prefix=counter_prefix,
         ):
-            self.publish(stat_name, stat_value)
+            self.publish(stat_name, stat_value, metric_type='GAUGE')
 
     def collect(self):
         """


### PR DESCRIPTION
Changed default metric type as gauge instead of counter
