### PR TITLE
Add extended stats to postgres collector

### DIFF
--- a/src/collectors/postgres/postgres.py
+++ b/src/collectors/postgres/postgres.py
@@ -69,7 +69,7 @@ class PostgresqlCollector(diamond.collector.Collector):
 
         # Iterate every QueryStats class
         for klass in metrics.itervalues():
-            stat = klass(self.connections)
+            stat = klass(self.connections, underscore=self.config['underscore'])
             stat.fetch()
             [self.publish(metric, value) for metric, value in stat]
 
@@ -118,11 +118,12 @@ def extended(cls):
 
 
 class QueryStats(object):
-    def __init__(self, conns):
+    def __init__(self, conns, underscore=False):
         self.connections = conns
+        self.underscore = underscore
 
     def _translate_datname(self, db):
-        if self.config['underscore']:
+        if self.underscore:
             db = db.replace("_", ".")
         return db
 


### PR DESCRIPTION
I refactored the postgres collector in a way that _should_ be backwards compatible with the previous implementation, and added the option to collect extended statistics at a more granular level. This has the potential to add thousands of extra data points to graphite (which we've found useful but may not be desirable in every scenario), so I've made the extra data optional for now.

The additional data includes table- and index-level stats, as well as the default queries included with Munin for their postgres collector.
