### PR TITLE
Fix class decorators

### DIFF
--- a/src/collectors/postgres/postgres.py
+++ b/src/collectors/postgres/postgres.py
@@ -435,7 +435,7 @@ class TupleAccessStats(QueryStats):
 registry = {
     'basic': (
         DatabaseStats,
-        DatabaseConnectionCount
+        DatabaseConnectionCount,
     ),
     'extended': (
         DatabaseStats,


### PR DESCRIPTION
Replace class decorators with a more verbose declaration of the mapping.
