### PR TITLE
Fix for monit if services are set to not be monitored

### DIFF
--- a/src/collectors/monit/test/testmonit.py
+++ b/src/collectors/monit/test/testmonit.py
@@ -28,7 +28,7 @@ class TestMonitCollector(CollectorTestCase):
     @patch.object(Collector, 'publish')
     def test_should_work_with_real_data(self, publish_mock):
         patch_urlopen = patch('urllib2.urlopen', Mock(
-            return_value=self.getFixture('status2.xml')))
+            return_value=self.getFixture('status.xml')))
 
         patch_urlopen.start()
         self.collector.collect()


### PR DESCRIPTION
When monit can't monitor a service, it will display no cpu/memory. So adding a try around where it parses the xml to skip any services that aren't monitored. 
