### PR TITLE
Add multiple instance support to mongodb collector

### DIFF
--- a/src/collectors/mongodb/mongodb.py
+++ b/src/collectors/mongodb/mongodb.py
@@ -31,7 +31,9 @@ class MongoDBCollector(diamond.collector.Collector):
     def get_default_config_help(self):
         config_help = super(MongoDBCollector, self).get_default_config_help()
         config_help.update({
-            'host': 'Hostname',
+            'hosts': 'Array of hostname(:port) elements to get metrics from',
+            'host': 'A single hostname(:port) to get metrics from'
+                   ' (can be used instead of hosts and overrides it)',
             'databases': 'A regex of which databases to gather metrics for.'
                         ' Defaults to all databases.',
             'ignore_collections': 'A regex of which collections to ignore.'
@@ -48,7 +50,7 @@ class MongoDBCollector(diamond.collector.Collector):
         config = super(MongoDBCollector, self).get_default_config()
         config.update({
             'path':      'mongo',
-            'host':      'localhost',
+            'hosts':     ['localhost'],
             'databases': '.*',
             'ignore_collections': '^tmp\.mr\.',
         })
@@ -61,34 +63,46 @@ class MongoDBCollector(diamond.collector.Collector):
             self.log.error('Unable to import pymongo')
             return {}
 
-        try:
-            if ReadPreference is None:
-                conn = pymongo.Connection(self.config['host'])
-            else:
-                conn = pymongo.Connection(
-                    self.config['host'],
-                    read_preference=ReadPreference.SECONDARY)
-        except Exception, e:
-            self.log.error('Couldnt connect to mongodb: %s', e)
-            return {}
-        data = conn.db.command('serverStatus')
-        self._publish_dict_with_prefix(data, [])
+        # we need this for backwards compatibility
+        if 'host' in self.config:
+            self.config['hosts'] = [self.config['host']]
 
-        db_name_filter = re.compile(self.config['databases'])
-        ignored_collections = re.compile(self.config['ignore_collections'])
-        for db_name in conn.database_names():
-            if not db_name_filter.search(db_name):
-                continue
-            db_stats = conn[db_name].command('dbStats')
-            self._publish_dict_with_prefix(db_stats, ['databases', db_name])
-            for collection_name in conn[db_name].collection_names():
-                if ignored_collections.search(collection_name):
+        for host in self.config['hosts']:
+            if len(self.config['hosts']) == 1:
+                # one host only, no need to have a prefix
+                base_prefix = []
+            else:
+                base_prefix = [re.sub('[:\.]', '_', host)]
+
+            try:
+                if ReadPreference is None:
+                    conn = pymongo.Connection(host)
+                else:
+                    conn = pymongo.Connection(
+                        host,
+                        read_preference=ReadPreference.SECONDARY)
+            except Exception, e:
+                self.log.error('Couldnt connect to mongodb: %s', e)
+                return {}
+            data = conn.db.command('serverStatus')
+            self._publish_dict_with_prefix(data, base_prefix)
+
+            db_name_filter = re.compile(self.config['databases'])
+            ignored_collections = re.compile(self.config['ignore_collections'])
+            for db_name in conn.database_names():
+                if not db_name_filter.search(db_name):
                     continue
-                collection_stats = conn[db_name].command('collstats',
-                                                         collection_name)
-                self._publish_dict_with_prefix(collection_stats,
-                                               ['databases', db_name,
-                                                collection_name])
+                db_stats = conn[db_name].command('dbStats')
+                db_prefix = base_prefix + ['databases', db_name]
+                self._publish_dict_with_prefix(db_stats, db_prefix)
+                for collection_name in conn[db_name].collection_names():
+                    if ignored_collections.search(collection_name):
+                        continue
+                    collection_stats = conn[db_name].command('collstats',
+                                                             collection_name)
+                    collection_prefix = db_prefix + [collection_name]
+                    self._publish_dict_with_prefix(collection_stats,
+                                                   collection_prefix)
 
     def _publish_dict_with_prefix(self, dict, prefix):
         for key in dict:

--- a/src/collectors/mongodb/test/testmongodb.py
+++ b/src/collectors/mongodb/test/testmongodb.py
@@ -141,6 +141,128 @@ class TestMongoDBCollector(CollectorTestCase):
         self.connection.database_names.return_value = ['db1', 'baddb']
 
 
+class TestMongoMultiHostDBCollector(CollectorTestCase):
+    def setUp(self):
+        config = get_collector_config('MongoDBCollector', {
+            'hosts': ['localhost:27017', 'localhost:27057'],
+            'databases': '^db',
+        })
+        self.collector = MongoDBCollector(config, None)
+        self.connection = MagicMock()
+
+    def test_import(self):
+        self.assertTrue(MongoDBCollector)
+
+    @run_only_if_pymongo_is_available
+    @patch('pymongo.Connection')
+    @patch.object(Collector, 'publish')
+    def test_should_publish_nested_keys_for_server_stats(self,
+                                                         publish_mock,
+                                                         connector_mock):
+        data = {'more_keys': {'nested_key': 1}, 'key': 2, 'string': 'str'}
+        self._annotate_connection(connector_mock, data)
+
+        self.collector.collect()
+
+        self.connection.db.command.assert_called_with('serverStatus')
+        self.assertPublishedMany(publish_mock, {
+            'localhost_27017.more_keys.nested_key': 1,
+            'localhost_27057.more_keys.nested_key': 1,
+            'localhost_27017.key': 2,
+            'localhost_27057.key': 2
+        })
+
+    @run_only_if_pymongo_is_available
+    @patch('pymongo.Connection')
+    @patch.object(Collector, 'publish')
+    def test_should_publish_nested_keys_for_db_stats(self,
+                                                     publish_mock,
+                                                     connector_mock):
+        data = {'db_keys': {'db_nested_key': 1}, 'dbkey': 2, 'dbstring': 'str'}
+        self._annotate_connection(connector_mock, data)
+
+        self.collector.collect()
+
+        self.connection['db1'].command.assert_called_with('dbStats')
+        metrics = {
+            'localhost_27017.db_keys.db_nested_key': 1,
+            'localhost_27057.db_keys.db_nested_key': 1,
+            'localhost_27017.dbkey': 2,
+            'localhost_27057.dbkey': 2
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    @run_only_if_pymongo_is_available
+    @patch('pymongo.Connection')
+    @patch.object(Collector, 'publish')
+    def test_should_publish_stats_with_long_type(self,
+                                                 publish_mock,
+                                                 connector_mock):
+        data = {'more_keys': long(1), 'key': 2, 'string': 'str'}
+        self._annotate_connection(connector_mock, data)
+
+        self.collector.collect()
+
+        self.connection.db.command.assert_called_with('serverStatus')
+        self.assertPublishedMany(publish_mock, {
+            'localhost_27017.more_keys': 1,
+            'localhost_27057.more_keys': 1,
+            'localhost_27017.key': 2,
+            'localhost_27057.key': 2
+        })
+
+    @run_only_if_pymongo_is_available
+    @patch('pymongo.Connection')
+    @patch.object(Collector, 'publish')
+    def test_should_ignore_unneeded_databases(self,
+                                              publish_mock,
+                                              connector_mock):
+        self._annotate_connection(connector_mock, {})
+
+        self.collector.collect()
+
+        assert call('baddb') not in self.connection.__getitem__.call_args_list
+
+    @run_only_if_pymongo_is_available
+    @patch('pymongo.Connection')
+    @patch.object(Collector, 'publish')
+    def test_should_ignore_unneeded_collections(self,
+                                                publish_mock,
+                                                connector_mock):
+        data = {'more_keys': long(1), 'key': 2, 'string': 'str'}
+        self._annotate_connection(connector_mock, data)
+
+        self.connection['db1'].collection_names.return_value = ['collection1',
+                                                                'tmp.mr.tmp1']
+        self.connection['db1'].command.return_value = {'key': 2,
+                                                       'string': 'str'}
+
+        self.collector.collect()
+
+        self.connection.db.command.assert_called_with('serverStatus')
+        self.connection['db1'].collection_names.assert_called_with()
+        self.connection['db1'].command.assert_any_call('dbStats')
+        self.connection['db1'].command.assert_any_call('collstats',
+                                                       'collection1')
+        assert call('collstats', 'tmp.mr.tmp1') not in \
+                self.connection['db1'].command.call_args_list
+        metrics = {
+            'localhost_27017.databases.db1.collection1.key': 2,
+            'localhost_27057.databases.db1.collection1.key': 2,
+        }
+
+        self.assertPublishedMany(publish_mock, metrics)
+
+    def _annotate_connection(self, connector_mock, data):
+        connector_mock.return_value = self.connection
+        self.connection.db.command.return_value = data
+        self.connection.database_names.return_value = ['db1', 'baddb']
+
+
 ################################################################################
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Users can now define a list of hosts and collector will be fetching metrics from all of them. This is useful when you run several mongo instances on the same host (shard server and configuration server, for example).

The change is backwards-compatible.
