### PR TITLE
fix metric_types for beanstalkd

### DIFF
--- a/src/collectors/beanstalkd/beanstalkd.py
+++ b/src/collectors/beanstalkd/beanstalkd.py
@@ -79,6 +79,7 @@ class BeanstalkdCollector(diamond.collector.Collector):
                 if stat != 'name':
                     self.publish('tubes.%s.%s' % (tube, stat), value,
                                  metric_type=self.get_metric_type(stat))
+
     def get_metric_type(self, stat):
         if self.COUNTERS_REGEX.match(stat):
             return 'COUNTER'


### PR DESCRIPTION
When setting up beanstalkd with a Librato handler, I noticed that it
wasn't reporting the metric types correctly. This patch will whitelist
stats that are known to be counters (tested with beanstalkd 1.4.6) and
default to GAUGE for everything else.
