### PR TITLE
default metric_type to GAUGE

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -301,7 +301,7 @@ class Collector(object):
         raise NotImplementedError()
 
     def publish(self, name, value, raw_value=None, precision=0,
-                metric_type='COUNTER'):
+                metric_type='GAUGE'):
         """
         Publish a metric with the given name
         """


### PR DESCRIPTION
While setting up Librato, I noticed that multiple collectors are not
setting the metric_type parameter (important ones, such as cpu and
network), and thus getting the default of COUNTER. They then getting
recorded wrong and show up as a flat graph. I think COUNTER is the
wrong default, as most metrics collected by Diamond are actually of
GAUGE type. It is also much easier to tell when a counter is accidently
being reported as a guage than when a gauge is being reported as a
counter.
