### PR TITLE
Fix MemcachedCollector

### DIFF
--- a/src/collectors/memcached/memcached.py
+++ b/src/collectors/memcached/memcached.py
@@ -111,7 +111,10 @@ class MemcachedCollector(diamond.collector.Collector):
             elif pieces[1] == 'pid':
                 pid = pieces[2]
                 continue
-            stats[pieces[1]] = pieces[2]
+            if '.' in pieces[2]:
+                stats[pieces[1]] = float(pieces[2])
+            else:
+                stats[pieces[1]] = int(pieces[2])
 
         # get max connection limit
         self.log.debug('pid %s', pid)


### PR DESCRIPTION
MemcachedCollector tests do not run the collector twice.
if `MemcachedCollector.collector()` run twice, `diamond.collector.Collector.derivative` is executed and it fail because metrics value are string:

```
Traceback (most recent call last):
  File "/usr/local/diamond/src/diamond/src/diamond/collector.py", line 393, in _run
     self.collect()
  File "/usr/local/diamond/src/diamond/src/collectors/memcached/memcached.py", line 160, in collect
    self.publish_counter(alias + "." + stat, stats[stat])
  File "/usr/local/diamond/src/diamond/src/diamond/collector.py", line 336, in publish_counter
    allow_negative=allow_negative)
  File "/usr/local/diamond/src/diamond/src/diamond/collector.py", line 355, in derivative
    derivative_x = new - old
TypeError: unsupported operand type(s) for -: 'str' and 'str'
```

this pull request fix the value type, but I tried to change the tests to run twice, like in http collector test, but I ends with this:

```
Traceback (most recent call last):
  File "/Users/ben/sandbox/external/Diamond/env/lib/python2.7/site-packages/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/Users/ben/sandbox/external/Diamond/src/collectors/memcached/test/testmemcached.py", line 98, in test_should_work_with_real_data
    self.assertPublishedMany(publish_mock, metrics)
  File "/Users/ben/sandbox/external/Diamond/test.py", line 173, in assertPublishedMany
    self.assertPublished(mock, key, value, expected_value)
  File "/Users/ben/sandbox/external/Diamond/test.py", line 145, in assertPublished
    self.assertEqual(actual_value, expected_value, message)
AssertionError: localhost.cmd_set: actual number of calls 2, expected 1
```

which is weird, because the value of cmd_set is 0 in both fixtures files and expected metrics.

So, I ends with only a fix and no test :sweat:
