### PR TITLE
Fix broken shortened URL

### DIFF
--- a/src/collectors/diskusage/diskusage.py
+++ b/src/collectors/diskusage/diskusage.py
@@ -257,7 +257,8 @@ class DiskUsageCollector(diamond.collector.Collector):
                                      + metrics['writes_milliseconds'])
                                     / metrics['io'])
 
-                # http://scr.bi/OnsGg4 Page 28
+                # http://www.scribd.com/doc/15013525/Your-Disk-Array-is-Slower-Than-it-Should-Be
+                # Page 28
                 metrics['concurrent_io'] = (metrics['reads_per_second']
                                             + metrics['writes_per_second']
                                             ) * (metrics['service_time']


### PR DESCRIPTION
The existing URL gives me an error page on bit.ly; replaced with the real URL. Less linkrot == better!
