### PR TITLE
Fixed the postgres collector so that if no database is specified it's no...

### DIFF
--- a/src/collectors/postgres/postgres.py
+++ b/src/collectors/postgres/postgres.py
@@ -92,13 +92,18 @@ class PostgresqlCollector(diamond.collector.Collector):
             datnames = ['postgres']
         return datnames
 
-    def _connect(self, database=''):
-        conn = psycopg2.connect(
-            host=self.config['host'],
-            user=self.config['user'],
-            password=self.config['password'],
-            port=self.config['port'],
-            database=database)
+    def _connect(self, database=None):
+        conn_args = {
+          'host':self.config['host'],
+          'user':self.config['user'],
+          'password':self.config['password'],
+          'port':self.config['port']
+        }
+
+        if database:
+          conn_args['database'] = database
+
+        conn = psycopg2.connect(**conn_args)
 
         # Avoid using transactions, set isolation level to autocommit
         conn.set_isolation_level(0)


### PR DESCRIPTION
...t passed to psycopg2. This allows it to establish a non-db connection properly over TCP as opposed to erroring out
