### PR TITLE
Fix StatsdHandler._send bug after ce5c6001ae75969f56c8bb5bdc150e6c38104ce2 rewrite

### DIFF
--- a/src/diamond/handler/stats_d.py
+++ b/src/diamond/handler/stats_d.py
@@ -66,9 +66,9 @@ class StatsdHandler(Handler):
         self.metrics.append(metric)
 
         if len(self.metrics) >= self.batch_size:
-            self._send(metric)
+            self._send()
 
-    def _send(self, metric):
+    def _send(self):
         """
         Send data to statsd. Fire and forget.  Cross fingers and it'll arrive.
         """


### PR DESCRIPTION
It seems that since [this commit](https://github.com/BrightcoveOS/Diamond/commit/ce5c6001ae75969f56c8bb5bdc150e6c38104ce2#src/diamond/handler/stats_d.py) a bug was introduced on `StatsdHandler._send` as it doesn't require the `metric` argument anymore.

I found it reading diamond' s logs:

```
[2013-04-30 13:40:24,617] [Thread-1] Traceback (most recent call last):
  File "/home/virtualenv/diamond/local/lib/python2.7/site-packages/diamond/handler/Handler.py", line 52, in _flush
    self.flush()
  File "/home/virtualenv/diamond/local/lib/python2.7/site-packages/diamond/handler/stats_d.py", line 98, in flush
    self._send()
TypeError: _send() takes exactly 2 arguments (1 given) 
```
