### PR TITLE
Fix TypeError: an integer is required in BeanstalkdCollector

### DIFF
--- a/src/collectors/beanstalkd/beanstalkd.py
+++ b/src/collectors/beanstalkd/beanstalkd.py
@@ -50,7 +50,7 @@ class BeanstalkdCollector(diamond.collector.Collector):
         stats = {}
         try:
             connection = beanstalkc.Connection(self.config['host'],
-                                               self.config['port'])
+                                               int(self.config['port']))
         except beanstalkc.BeanstalkcException, e:
             self.log.error("Couldn't connect to beanstalkd: %s", e)
             return {}


### PR DESCRIPTION
If a custom port is defined in the collector config, it's not converted to an int.
