### PR TITLE
Change the deb pid file location back to /var/run

### DIFF
--- a/debian/diamond.default
+++ b/debian/diamond.default
@@ -8,5 +8,5 @@
 
 # Additional options that are passed to the Daemon.
 ENABLE_DIAMOND="yes"
-DIAMOND_PID="/var/run/diamond/diamond.pid"
+DIAMOND_PID="/var/run/diamond.pid"
 DIAMOND_USER="diamond"

--- a/debian/dirs
+++ b/debian/dirs
@@ -1,3 +1,2 @@
 etc/diamond/collectors
 var/log/diamond
-var/run/diamond

--- a/debian/upstart/diamond.conf
+++ b/debian/upstart/diamond.conf
@@ -17,7 +17,7 @@ script
         . /etc/default/diamond
     else
         ENABLE_DIAMOND="yes"
-        DIAMOND_PID="/var/run/diamond/diamond.pid"
+        DIAMOND_PID="/var/run/diamond.pid"
         DIAMOND_USER="diamond"
     fi
 


### PR DESCRIPTION
Upon install diamond works fine, but does not restart once the the host machine is rebooted. Diamond cannot restart as the /var/run dir has been cleared by the reboot and a /var/run/diamond dir no longer exists.

This commit changes the pidfile location back to /var/run from /var/run/diamond. 
