### PR TITLE
set unit to B by default in doc string

### DIFF
--- a/src/collectors/processresources/processresources.py
+++ b/src/collectors/processresources/processresources.py
@@ -9,7 +9,7 @@ Example config file ProcessResourcesCollector.conf
 
 ```
 enabled=True
-unit=kB
+unit=B
 cpu_interval=0.1
 [process]
 [[postgres]]


### PR DESCRIPTION
Make the doc and code consistent.
