### PR TITLE
Elasticsearch collector - don't blow up if CPU, memory or file stats aren't present

### DIFF
--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -74,13 +74,12 @@ class ElasticSearchCollector(diamond.collector.Collector):
             self._copy_one_level(metrics, '%s.%s' % (prefix, key1), d1, filter)
 
     def _index_metrics(self, metrics, prefix, index):
-        if 'docs' in index:
-            metrics['%s.docs.count' % prefix] = index['docs']['count']
-            metrics['%s.docs.deleted' % prefix] = index['docs']['deleted']
-
-        if 'store' in index:
-            metrics['%s.datastore.size' % prefix] = index[
-                'store']['size_in_bytes']
+        self._add_metric(metrics, '%s.docs.count' % prefix, index,
+                         ['docs', 'count'])
+        self._add_metric(metrics, '%s.docs.deleted' % prefix, index,
+                         ['docs', 'deleted'])
+        self._add_metric(metrics, '%s.datastore.size' % prefix, index,
+                         ['store', 'size_in_bytes'])
 
         # publish all 'total' and 'time_in_millis' stats
         self._copy_two_level(metrics, prefix, index,


### PR DESCRIPTION
On our system (using latest elastic search), stats for CPU, memory and file usage aren't present in the JSON response, so the collector blows up.  

This patch adds an _add_metric method to the collector which checks for the existence of each JSON element.
