### PR TITLE
use SIGKILL instead of default signal in gentoo init.d script

### DIFF
--- a/gentoo/init.d
+++ b/gentoo/init.d
@@ -31,7 +31,7 @@ stop() {
 	fi
 
 	ebegin "Stopping ${SVCNAME}"
-	kill ${PID}
+	kill -9 ${PID}
 
 	i=0
 	while ( test -f "${PIDFILE}" && pgrep -P ${PID} diamond >/dev/null ) \


### PR DESCRIPTION
As I often can not stop diamond process with this default:

``` bash
kill ${PID}
```

so I use:

```
kill -9 ${PID}
```
