### PR TITLE
Add Alias Support to mongodb collector

### DIFF
--- a/src/collectors/mongodb/mongodb.py
+++ b/src/collectors/mongodb/mongodb.py
@@ -36,7 +36,8 @@ class MongoDBCollector(diamond.collector.Collector):
     def get_default_config_help(self):
         config_help = super(MongoDBCollector, self).get_default_config_help()
         config_help.update({
-            'hosts': 'Array of hostname(:port) elements to get metrics from',
+            'hosts': 'Array of hostname(:port) elements to get metrics from'
+                     'Set an alias by prefixing host:port with alias@',
             'host': 'A single hostname(:port) to get metrics from'
                     ' (can be used instead of hosts and overrides it)',
             'user': 'Username for authenticated login (optional)',
@@ -100,8 +101,15 @@ class MongoDBCollector(diamond.collector.Collector):
             if len(self.config['hosts']) == 1:
                 # one host only, no need to have a prefix
                 base_prefix = []
-            else:
-                base_prefix = [re.sub('[:\.]', '_', host)]
+            else:                
+                matches = re.search('((.+)\@)?(.+)?', host)
+                alias = matches.group(2)
+                host = matches.group(3)
+
+                if alias is None:
+                    base_prefix = [re.sub('[:\.]', '_', host)]
+                else:
+                    base_prefix = [alias]
 
             try:
                 if ReadPreference is None:


### PR DESCRIPTION
The memcache collector has a nice option with hosts lists where you can specify an alias name for each listed host.

eg.
hosts=cluster1@localhost:8000,cluster2@localhost:9000

I've used that a as a model to add similar support to mongodb collector.

(you might want to consider making 'hosts' a higher level primitive with generalized support at a higher level, but that's a much bigger task potentially hitting LOTS of collector code)

Tested in my environment.

Cheers,

Joel Krauska
