### PR TITLE
multi graphite pickle should be good like "multi graphite" one

### DIFF
--- a/src/diamond/handler/multigraphitepickle.py
+++ b/src/diamond/handler/multigraphitepickle.py
@@ -1,0 +1,47 @@
+# coding=utf-8
+
+"""
+Send metrics to a [graphite](http://graphite.wikidot.com/) using the pickle
+interface. Unlike GraphitePickleHandler, this one supports multiple graphite servers.
+Specify them as a list of hosts divided by comma.
+"""
+
+from Handler import Handler
+from graphite import GraphitePickleHandler
+from copy import deepcopy
+
+
+class MultiGraphitePickleHandler(Handler):
+    """
+    Implements the abstract Handler class, sending data to multiple
+    graphite servers by using two instances of GraphitePickleHandler
+    """
+
+    def __init__(self, config=None):
+        """
+        Create a new instance of the MultiGraphitePickleHandler class
+        """
+        # Initialize Handler
+        Handler.__init__(self, config)
+
+        self.handlers = []
+
+        # Initialize Options
+        hosts = self.config['host']
+        for host in hosts:
+            config = deepcopy(self.config)
+            config['host'] = host
+            self.handlers.append(GraphitePickleHandler(config))
+
+    def process(self, metric):
+        """
+        Process a metric by passing it to GraphitePickleHandler
+        instances
+        """
+        for handler in self.handlers:
+            handler.process(metric)
+
+    def flush(self):
+        """Flush metrics in queue"""
+        for handler in self.handlers:
+            handler.flush()


### PR DESCRIPTION
We collect many metrics from our servers and send metrics directly to two different graphite servers in different sites.

We're using pickle because we collect so many metrics from each server with a short interval.

Actually our need and my solution (patch) is very similar to #328, I've just copied and changed th contents of multigraphite, maybe it should be better if we use same solution with the mongodb one as in aec83bb53ad7b9bde4b6e78643d3e4f51d215e49 (one handler with "host" and "hosts" config parameters instead of introducing new Multi\* handlers).

But I'm not sure about breaking the backward compatibility, so I've just added a new handler for now.
