### PR TITLE
Database nickname not prepended to derivative values

### DIFF
--- a/src/collectors/mysql/mysql.py
+++ b/src/collectors/mysql/mysql.py
@@ -408,7 +408,7 @@ class MySQLCollector(diamond.collector.Collector):
                     continue
 
                 if metric_name not in self._GAUGE_KEYS:
-                    metric_value = self.derivative(metric_name,
+                    metric_value = self.derivative(nickname + metric_name,
                                                    metric_value)
                 if key == 'status':
                     if ('publish' not in self.config


### PR DESCRIPTION
In the case of polling multiple databases differentiated by nicknames, the nickname is not prepended to the metric name.  Since diamond.Collector.derivative stores the last value in a dict with the metric name as the key, polling multiple databases will continually overwrite the old value, introducing errors into the derivative value for that metric for all databases.
