### PR TITLE
added jcollect network listener collector

### DIFF
--- a/src/collectors/jcollectd/collectd_network.py
+++ b/src/collectors/jcollectd/collectd_network.py
@@ -1,0 +1,353 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim: fileencoding=utf-8
+#
+# Copyright © 2009 Adrian Perez <aperez@igalia.com>
+#
+# Distributed under terms of the GPLv2 license or newer.
+#
+#
+# Renzo Toma (rtoma@bol.com) 6 Aug 2013
+# - added non-blocking I/O for receive
+#
+# Frank Marien (frank@apsu.be) 6 Sep 2012
+# - quick fixes for 5.1 binary protocol
+# - updated to python 3
+# - fixed for larger packet sizes (possible on lo interface)
+# - fixed comment typo (decode_network_string decodes a string)
+#
+# @see: https://raw.github.com/collectd/collectd/master/contrib/collectd_network.py
+
+"""
+Collectd network protocol implementation.
+"""
+
+import socket
+import struct
+import select
+import platform
+if platform.python_version() < '2.8.0':
+    # Python 2.7 and below io.StringIO does not like unicode
+    from StringIO import StringIO
+else:
+    try:
+        from io import StringIO
+    except ImportError:
+        from cStringIO import StringIO
+
+from datetime import datetime
+from copy import deepcopy
+
+
+DEFAULT_PORT = 25826
+"""Default port"""
+
+DEFAULT_IPv4_GROUP = "239.192.74.66"
+"""Default IPv4 multicast group"""
+
+DEFAULT_IPv6_GROUP = "ff18::efc0:4a42"
+"""Default IPv6 multicast group"""
+
+HR_TIME_DIV = (2.0 ** 30)
+
+# Message kinds
+TYPE_HOST            = 0x0000
+TYPE_TIME            = 0x0001
+TYPE_TIME_HR         = 0x0008
+TYPE_PLUGIN          = 0x0002
+TYPE_PLUGIN_INSTANCE = 0x0003
+TYPE_TYPE            = 0x0004
+TYPE_TYPE_INSTANCE   = 0x0005
+TYPE_VALUES          = 0x0006
+TYPE_INTERVAL        = 0x0007
+TYPE_INTERVAL_HR     = 0x0009
+
+# For notifications
+TYPE_MESSAGE         = 0x0100
+TYPE_SEVERITY        = 0x0101
+
+# DS kinds
+DS_TYPE_COUNTER      = 0
+DS_TYPE_GAUGE        = 1
+DS_TYPE_DERIVE       = 2
+DS_TYPE_ABSOLUTE     = 3
+
+header = struct.Struct("!2H")
+number = struct.Struct("!Q")
+short  = struct.Struct("!H")
+double = struct.Struct("<d")
+
+
+def decode_network_values(ptype, plen, buf):
+    """Decodes a list of DS values in collectd network format
+    """
+    nvalues = short.unpack_from(buf, header.size)[0]
+    off = header.size + short.size + nvalues
+    valskip = double.size
+
+    # Check whether our expected packet size is the reported one
+    assert ((valskip + 1) * nvalues + short.size + header.size) == plen
+    assert double.size == number.size
+
+    result = []
+    for dstype in [ord(x) for x in buf[header.size+short.size:off]]:
+        if dstype == DS_TYPE_COUNTER:
+            result.append((dstype, number.unpack_from(buf, off)[0]))
+            off += valskip
+        elif dstype == DS_TYPE_GAUGE:
+            result.append((dstype, double.unpack_from(buf, off)[0]))
+            off += valskip
+        elif dstype == DS_TYPE_DERIVE:
+            result.append((dstype, number.unpack_from(buf, off)[0]))
+            off += valskip
+        elif dstype == DS_TYPE_ABSOLUTE:
+            result.append((dstype, number.unpack_from(buf, off)[0]))
+            off += valskip
+        else:
+            raise ValueError("DS type %i unsupported" % dstype)
+
+    return result
+
+
+def decode_network_number(ptype, plen, buf):
+    """Decodes a number (64-bit unsigned) from collectd network format.
+    """
+    return number.unpack_from(buf, header.size)[0]
+
+
+def decode_network_string(msgtype, plen, buf):
+    """Decodes a string from collectd network format.
+    """
+    return buf[header.size:plen-1]
+
+
+# Mapping of message types to decoding functions.
+_decoders = {
+    TYPE_VALUES         : decode_network_values,
+    TYPE_TIME           : decode_network_number,
+    TYPE_TIME_HR        : decode_network_number,
+    TYPE_INTERVAL       : decode_network_number,
+    TYPE_INTERVAL_HR    : decode_network_number,
+    TYPE_HOST           : decode_network_string,
+    TYPE_PLUGIN         : decode_network_string,
+    TYPE_PLUGIN_INSTANCE: decode_network_string,
+    TYPE_TYPE           : decode_network_string,
+    TYPE_TYPE_INSTANCE  : decode_network_string,
+    TYPE_MESSAGE        : decode_network_string,
+    TYPE_SEVERITY       : decode_network_number,
+}
+
+
+def decode_network_packet(buf):
+    """Decodes a network packet in collectd format.
+    """
+    off = 0
+    blen = len(buf)
+
+    while off < blen:
+        ptype, plen = header.unpack_from(buf, off)
+
+        if plen > blen - off:
+            raise ValueError("Packet longer than amount of data in buffer")
+
+        if ptype not in _decoders:
+            raise ValueError("Message type %i not recognized" % ptype)
+
+        yield ptype, _decoders[ptype](ptype, plen, buf[off:])
+        off += plen
+
+
+class Data(object):
+    time = 0
+    host = None
+    plugin = None
+    plugininstance = None
+    type = None
+    typeinstance = None
+
+    def __init__(self, **kw):
+        [setattr(self, k, v) for k, v in kw.items()]
+
+    @property
+    def datetime(self):
+        return datetime.fromtimestamp(self.time)
+
+    @property
+    def source(self):
+        buf = StringIO()
+        if self.host:
+            buf.write(str(self.host))
+        if self.plugin:
+            buf.write("/")
+            buf.write(str(self.plugin))
+        if self.plugininstance:
+            buf.write("/")
+            buf.write(str(self.plugininstance))
+        if self.type:
+            buf.write("/")
+            buf.write(str(self.type))
+        if self.typeinstance:
+            buf.write("/")
+            buf.write(str(self.typeinstance))
+        return buf.getvalue()
+
+    def __str__(self):
+        return "[%i] %s" % (self.time, self.source)
+
+
+class Notification(Data):
+    FAILURE  = 1
+    WARNING  = 2
+    OKAY     = 4
+
+    SEVERITY = {
+        FAILURE: "FAILURE",
+        WARNING: "WARNING",
+        OKAY   : "OKAY",
+    }
+
+    __severity = 0
+    message  = ""
+
+    def __set_severity(self, value):
+        if value in (self.FAILURE, self.WARNING, self.OKAY):
+            self.__severity = value
+
+    severity = property(lambda self: self.__severity, __set_severity)
+
+    @property
+    def severitystring(self):
+        return self.SEVERITY.get(self.severity, "UNKNOWN")
+
+    def __str__(self):
+        return "%s [%s] %s" % (
+               super(Notification, self).__str__(),
+               self.severitystring,
+               self.message)
+
+
+class Values(Data, list):
+    def __str__(self):
+        return "%s %s" % (Data.__str__(self), list.__str__(self))
+
+
+def interpret_opcodes(iterable):
+    vl = Values()
+    nt = Notification()
+
+    for kind, data in iterable:
+        if kind == TYPE_TIME:
+            vl.time = nt.time = data
+        elif kind == TYPE_TIME_HR:
+            vl.time = nt.time = data / HR_TIME_DIV
+        elif kind == TYPE_INTERVAL:
+            vl.interval = data
+        elif kind == TYPE_INTERVAL_HR:
+            vl.interval = data / HR_TIME_DIV
+        elif kind == TYPE_HOST:
+            vl.host = nt.host = data
+        elif kind == TYPE_PLUGIN:
+            vl.plugin = nt.plugin = data
+        elif kind == TYPE_PLUGIN_INSTANCE:
+            vl.plugininstance = nt.plugininstance = data
+        elif kind == TYPE_TYPE:
+            vl.type = nt.type = data
+        elif kind == TYPE_TYPE_INSTANCE:
+            vl.typeinstance = nt.typeinstance = data
+        elif kind == TYPE_SEVERITY:
+            nt.severity = data
+        elif kind == TYPE_MESSAGE:
+            nt.message = data
+            yield deepcopy(nt)
+        elif kind == TYPE_VALUES:
+            vl[:] = data
+            yield deepcopy(vl)
+
+
+class Reader(object):
+    """Network reader for collectd data.
+
+    Listens on the network in a given address, which can be a multicast
+    group address, and handles reading data when it arrives.
+    """
+    addr = None
+    host = None
+    port = DEFAULT_PORT
+
+    BUFFER_SIZE = 16384
+
+    def __init__(self, host=None, port=DEFAULT_PORT, multicast=False):
+        if host is None:
+            multicast = True
+            host = DEFAULT_IPv4_GROUP
+
+        self.host, self.port = host, port
+        self.ipv6 = ":" in self.host
+
+        family, socktype, proto, canonname, sockaddr = socket.getaddrinfo(
+            None if multicast else self.host,
+            self.port,
+            socket.AF_INET6 if self.ipv6 else socket.AF_UNSPEC,
+            socket.SOCK_DGRAM, 0, socket.AI_PASSIVE)[0]
+
+        self._sock = socket.socket(family, socktype, proto)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(sockaddr)
+
+        if multicast:
+            if hasattr(socket, "SO_REUSEPORT"):
+                self._sock.setsockopt(
+                    socket.SOL_SOCKET,
+                    socket.SO_REUSEPORT, 1)
+
+            val = None
+            if family == socket.AF_INET:
+                assert "." in self.host
+                val = struct.pack("4sl",
+                                  socket.inet_aton(self.host), socket.INADDR_ANY)
+            elif family == socket.AF_INET6:
+                raise NotImplementedError("IPv6 support not ready yet")
+            else:
+                raise ValueError("Unsupported network address family")
+
+            self._sock.setsockopt(
+                socket.IPPROTO_IPV6 if self.ipv6 else socket.IPPROTO_IP,
+                socket.IP_ADD_MEMBERSHIP, val)
+            self._sock.setsockopt(
+                socket.IPPROTO_IPV6 if self.ipv6 else socket.IPPROTO_IP,
+                socket.IP_MULTICAST_LOOP, 0)
+
+        self._readlist = [self._sock]
+
+    def receive(self, poll_interval):
+        """Receives a single raw collect network packet.
+        """
+        readable, writeable, errored = select.select(self._readlist, [], [], poll_interval)
+        for s in readable:
+            data, addr = s.recvfrom(self.BUFFER_SIZE)
+            if data:
+                return data
+
+        return None
+
+    def decode(self, poll_interval, buf=None):
+        """Decodes a given buffer or the next received packet.
+        """
+        if buf is None:
+            buf = self.receive(poll_interval)
+        if buf is None:
+            return None
+        return decode_network_packet(buf)
+
+    def interpret(self, iterable=None, poll_interval=0.2):
+        """Interprets a sequence
+        """
+        if iterable is None:
+            iterable = self.decode(poll_interval)
+            if iterable is None:
+                return None
+
+        if isinstance(iterable, str):
+            iterable = self.decode(poll_interval, iterable)
+
+        return interpret_opcodes(iterable)

--- a/src/collectors/jcollectd/jcollectd.py
+++ b/src/collectors/jcollectd/jcollectd.py
@@ -1,0 +1,166 @@
+# coding=utf-8
+
+import threading
+import re
+import Queue
+
+import diamond.collector
+import diamond.metric
+
+import collectd_network
+
+
+ALIVE = True
+
+
+class JCollectdCollector(diamond.collector.Collector):
+
+    def __init__(self, *args, **kwargs):
+        super(JCollectdCollector, self).__init__(*args, **kwargs)
+        self.listener_thread = None
+
+    def get_default_config(self):
+        """
+        Returns the default collector settings
+        """
+        config = super(JCollectdCollector, self).get_default_config()
+        config.update({
+            'path':     'jvm',
+            'enabled':  'True',
+            'method':   'Threaded',
+            'listener_host': '127.0.0.1',
+            'listener_port': 25826,
+        })
+        return config
+
+    def collect(self):
+        if not self.listener_thread:
+            self.start_listener()
+
+        q = self.listener_thread.queue
+        while True:
+            try:
+                dp = q.get(False)
+                metric = self.make_metric(dp)
+            except Queue.Empty:
+                break
+            self.publish_metric(metric)
+
+    def start_listener(self):
+        self.listener_thread = ListenerThread(self.config['listener_host'], self.config['listener_port'], self.log)
+        self.listener_thread.start()
+
+    def stop_listener(self):
+        global ALIVE
+        ALIVE = False
+        self.listener_thread.join()
+        self.log.error('Listener thread is shut down.')
+
+    def make_metric(self, dp):
+
+        path = ".".join((dp.host, self.config['path'], dp.name))
+
+        if 'path_prefix' in self.config:
+            prefix = self.config['path_prefix']
+            if prefix:
+                path = ".".join((prefix, path))
+
+        if 'path_suffix' in self.config:
+            suffix = self.config['path_suffix']
+            if suffix:
+                path = ".".join((path, suffix))
+
+        metric_type = "COUNTER" if dp.is_counter else "GAUGE"
+        metric = diamond.metric.Metric(path, dp.value, dp.time, metric_type=metric_type)
+
+        return metric
+
+    def __del__(self):
+        if self.listener_thread:
+            self.stop_listener()
+
+
+class ListenerThread(threading.Thread):
+    def __init__(self, host, port, log, poll_interval=0.4):
+        super(ListenerThread, self).__init__()
+        self.name = 'JCollectdListener'  # thread name
+
+        self.host = host
+        self.port = port
+        self.log = log
+        self.poll_interval = poll_interval
+
+        self.queue = Queue.Queue()
+
+    def run(self):
+        self.log.info('ListenerThread started on {0}:{1}(udp)'.format(self.host, self.port))
+
+        rdr = collectd_network.Reader(self.host, self.port)
+
+        try:
+            while ALIVE:
+                items = rdr.interpret(poll_interval=self.poll_interval)
+                self.send_to_collector(items)
+        except Exception, e:
+            self.log.error('caught exception: type={0}, exc={1}'.format(type(e), e))
+
+        self.log.info('ListenerThread - stop')
+
+    def send_to_collector(self, items):
+        if items is None:
+            return
+
+        for item in items:
+            try:
+                metric = self.transform(item)
+                self.queue.put(metric)
+            except Queue.Full:
+                self.log.error('Queue to collector is FULL')
+            except Exception, e:
+                self.log.error('B00M! type={0}, exception={1}'.format(type(e), e))
+
+    def transform(self, item):
+
+        parts = []
+
+        path = item.plugininstance
+        # extract jvm name from 'logstash-MemoryPool Eden Space'
+        if '-' in path:
+            (jvm, tail) = path.split('-', 1)
+            path = tail
+        else:
+            jvm = 'unnamed'
+
+        # add JVM name
+        parts.append(jvm)
+
+        # add mbean name (e.g. 'java_lang')
+        parts.append(item.plugin)
+
+        # get typed mbean: 'MemoryPool Eden Space'
+        if ' ' in path:
+            (mb_type, mb_name) = path.split(' ', 1)
+            parts.append(mb_type)
+            parts.append(mb_name)
+        else:
+            parts.append(path)
+
+        # add property name
+        parts.append(item.typeinstance)
+
+        # construct full path, from safe parts
+        name = '.'.join([re.sub('[\. ]', '_', part) for part in parts])
+
+        dp = Datapoint(item.host, item.time, name,
+                       item[0][1], True if item[0][0] == 0 else False)
+
+        return dp
+
+
+class Datapoint():
+    def __init__(self, host, time, name, value, is_counter):
+        self.host = host
+        self.time = time
+        self.name = name
+        self.value = value
+        self.is_counter = is_counter


### PR DESCRIPTION
This collector is able to receive metrics from one or more jcollectd instances. It has an UDP listener in a separate thread for this purpose. It does some try to extract the JVM instance name and make a nice metricname. (I hear you ask: "why are you using Diamond and not collectd?" Collectd's design does not allow for free metricnaming. You're stuck with 4 fields: plugin, plugininstance, type and typeinstance.)

Jcollectd can run as a java agent inside an JVM and gather metrics from mbeans. Normally jcollectd sends its data to a collectd server, but since the protocol is open and python code was available I made a Diamond collector.

Background info:
- https://collectd.org/wiki/index.php/Plugin:Network
- https://github.com/collectd/collectd/blob/master/contrib/collectd_network.py
- https://github.com/hyperic/jcollectd instances
