### PR TITLE
minor fix related to #366, was causing "Permission denied" exceptions on debian

### DIFF
--- a/bin/diamond
+++ b/bin/diamond
@@ -307,7 +307,7 @@ def main():
                 # Stop Server
                 server.stop()
                 # Delete Pidfile
-                if os.path.exists(options.pidfile):
+                if not options.skip_pidfile and os.path.exists(options.pidfile):
                     os.remove(options.pidfile)
                     # Log
                     log.debug("Removed PID file: %s" % (options.pidfile))

--- a/debian/upstart/diamond.conf
+++ b/debian/upstart/diamond.conf
@@ -23,6 +23,6 @@ script
 
   # Launch Diamond if enabled in /etc/default
   if [ "x$ENABLE_DIAMOND" = "xyes" ]; then 
-    exec start-stop-daemon --start --make-pidfile --chuid $DIAMOND_USER --pidfile $DIAMOND_PID --exec /usr/bin/diamond -- --foreground --skip-change-user --skip-fork --skip-pidfile -p $DIAMOND_PID
+    exec start-stop-daemon --start --make-pidfile --chuid $DIAMOND_USER --pidfile $DIAMOND_PID --exec /usr/bin/diamond -- --foreground --skip-change-user --skip-fork --skip-pidfile
   fi
 end script


### PR DESCRIPTION
/var/run/diamond.pid is owned by root on debian, but we pass it to diamond:

```
/usr/bin/python /usr/bin/diamond --foreground --skip-change-user --skip-fork --skip-pidfile -p /var/run/diamond.pid
```

resulting in:

```
[2013-08-07 16:20:17,108] [MainThread] Unhandled exception: [Errno 13] Permission denied: '/var/run/diamond.pid'
[2013-08-07 16:20:17,108] [MainThread] traceback: Traceback (most recent call last):
  File "/usr/bin/diamond", line 324, in main
    server.run()
  File "/usr/lib/pymodules/python2.7/diamond/server.py", line 342, in run
    self.mainloop()
  File "/usr/lib/pymodules/python2.7/diamond/server.py", line 392, in mainloop
    time.sleep(1)
  File "/usr/bin/diamond", line 311, in sigint_handler
    os.remove(options.pidfile)
OSError: [Errno 13] Permission denied: '/var/run/diamond.pid'
```

I guess diamond shouldn't try to delete it if --skip-pidfile is set, or it shouldn't be passed in the init.d script at all (or both)
