### PR TITLE
Test + fix for non-real files causing exceptions in userscriptscollector

### DIFF
--- a/src/collectors/userscripts/test/fixtures/ohnoafolder/ignoreme.txt
+++ b/src/collectors/userscripts/test/fixtures/ohnoafolder/ignoreme.txt
@@ -1,0 +1,1 @@
+Just here so git preserves the folder I'm in.

--- a/src/collectors/userscripts/test/testuserscripts.py
+++ b/src/collectors/userscripts/test/testuserscripts.py
@@ -57,6 +57,14 @@ class TestUserScriptsCollector(CollectorTestCase):
                            metrics=metrics)
         self.assertPublishedMany(publish_mock, metrics)
 
+    @run_only_if_kitchen_is_available
+    @patch.object(Collector, 'publish')
+    def test_should_skip_over_unrunnable_files(self, publish_mock):
+        self.collector.collect()
+        # Just make sure publish got called >0 times, if this test fails it'll
+        # be due to raising an exception. Meh.
+        assert publish_mock.call_args_list
+
 ################################################################################
 if __name__ == "__main__":
     unittest.main()

--- a/src/collectors/userscripts/userscripts.py
+++ b/src/collectors/userscripts/userscripts.py
@@ -69,8 +69,15 @@ class UserScriptsCollector(diamond.collector.Collector):
             return None
         for script in os.listdir(scripts_path):
             absolutescriptpath = os.path.join(scripts_path, script)
-            if not os.access(absolutescriptpath, os.X_OK):
-                self.log.info("%s is not executable" % absolutescriptpath)
+            executable = os.access(absolutescriptpath, os.X_OK)
+            is_file = os.path.isfile(absolutescriptpath)
+            if is_file:
+                if not executable:
+                    self.log.info("%s is not executable" % absolutescriptpath)
+                    continue
+            else:
+                # Don't bother logging skipped non-file files (typically
+                # directories)
                 continue
             out = None
             self.log.debug("Executing %s" % absolutescriptpath)


### PR DESCRIPTION
This patch prevents Diamond's UserScriptsCollector from attempting to execute directories and other non-real "files" that happen to be set executable. When such a file makes its way into your userscripts folder (it can happen!) the collector would raise e.g. OSError or IOError, and cease execution.

Not only does this generate log spam, it (silently*) prevents any userscripts that would come after the bad file from executing.

Note that as of this commit 1 test is failing; this test failed prior to the commit as well. (It's in one of the puppet modules.)

---

\* Most other parts of Diamond behave in a sensible "complain and keep going" manner, so it's easy for administrators to see a traceback and assume that only the one file causing the traceback was skipped. In this situation that's not the case.
