### PR TITLE
add a collector for supervisord

### DIFF
--- a/src/collectors/supervisord/supervisord.py
+++ b/src/collectors/supervisord/supervisord.py
@@ -1,0 +1,89 @@
+# coding=utf-8
+
+"""
+Custom collector for supervisord process control system (github.com/Supervisor/supervisor)
+
+Supervisor runs an XML-RPC server, which this collector uses to gather a few basic stats on each registered process.
+
+#### Dependencies
+
+ * xmlrpclib
+ * supervisor
+ * diamond
+
+#### Usage
+
+Configure supervisor's XML-RPC server (either over HTTP or Unix socket). See supervisord.org/configuration.html for details. In the collector configuration file, you may specify the protocol and path configuration; below are the defaults. 
+<pre>
+xmlrpc_server_protocol = unix
+xmlrpc_server_path = /var/run/supervisor.sock
+</pre>
+
+"""
+
+import xmlrpclib
+import supervisor.xmlrpc
+import diamond.collector
+
+
+class SupervisordCollector(diamond.collector.Collector):
+
+    def get_default_config_help(self):
+        config_help = super(SupervisordCollector, self).get_default_config_help()
+        config_help.update({
+            'xmlrpc_server_protocol': 'XML-RPC server protocol. Options: unix (default), http',
+            'xmlrpc_server_path': 'XML-RPC server path. Default: /var/run/supervisor.sock'
+        })
+        return config_help
+
+    def get_default_config(self):
+        default_config = super(SupervisordCollector, self).get_default_config()
+        default_config['path'] = 'supervisor'
+        default_config['xmlrpc_server_protocol'] = 'unix'
+        default_config['xmlrpc_server_path'] = '/var/run/supervisor.sock'
+        return default_config
+
+    def getAllProcessInfo(self):
+
+        server = None
+        protocol = self.config['xmlrpc_server_protocol']
+        path = self.config['xmlrpc_server_path']
+        uri = '{0}://{1}'.format(protocol, path)
+
+        self.log.debug('Attempting to connect to XML-RPC server "{0}"'.format(uri))
+
+        if protocol == 'unix':
+            server = xmlrpclib.ServerProxy('http://127.0.0.1',
+                        supervisor.xmlrpc.SupervisorTransport(None, None, uri)
+                     ).supervisor
+
+        elif protocol == 'http':
+            server = xmlrpclib.Server(uri).supervisor
+
+        else:
+            self.log.debug('Invalid xmlrpc_server_protocol config setting "{0}"'.format(protocol))
+            return None
+
+        return server.getAllProcessInfo()
+
+    def collect(self):
+
+        processes = self.getAllProcessInfo()
+
+        self.log.debug('Found {0} supervisord processes'.format(len(processes)))
+
+        for process in processes:
+			statPrefix = str.format("%s.%s" % (process["group"], process["name"]))
+
+			# state
+
+			self.publish(statPrefix + ".state", process["state"])
+
+			# uptime
+
+			uptime = 0
+	
+			if process["statename"] == "RUNNING":
+				uptime = process["now"] - process["start"]
+
+			self.publish(statPrefix + ".uptime", uptime)

--- a/src/collectors/supervisord/test/fixtures/valid_fixture
+++ b/src/collectors/supervisord/test/fixtures/valid_fixture
@@ -1,0 +1,4 @@
+[
+{'now': 15, 'group': 'test_group', 'description': 'test_desc', 'pid': 0, 'stderr_logfile': 'test_stderrlog', 'stop': 20, 'statename': 'RUNNING', 'start': 10, 'state': 20, 'stdout_logfile': 'test_stdoutlog', 'logfile': 'test_log', 'exitstatus': 0, 'spawnerr': 'test_spawnerr', 'name': 'test_name_1'},
+{'now': 501, 'group': 'test_group', 'description': 'test_desc', 'pid': 0, 'stderr_logfile': 'test_stderrlog', 'stop': 20, 'statename': 'RUNNING', 'start': 1, 'state': 200, 'stdout_logfile': 'test_stdoutlog', 'logfile': 'test_log', 'exitstatus': 0, 'spawnerr': 'test_spawnerr', 'name': 'test_name_2'}
+]

--- a/src/collectors/supervisord/test/testsupervisord.py
+++ b/src/collectors/supervisord/test/testsupervisord.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+# coding=utf-8
+################################################################################
+
+from test import CollectorTestCase
+from test import get_collector_config
+from test import unittest
+from mock import Mock
+from mock import patch
+
+from diamond.collector import Collector
+from supervisord import SupervisordCollector
+
+################################################################################
+
+
+class TestSupervisordCollector(CollectorTestCase):
+    def setUp(self):
+        config = get_collector_config('SupervisordCollector', {})
+        self.collector = SupervisordCollector(config, None)
+        self.assertTrue(self.collector)
+
+    def test_import(self):
+        self.assertTrue(SupervisordCollector)
+
+    @patch.object(Collector, 'publish')
+    def test_success(self, publish_mock):
+
+        self.collector.getAllProcessInfo = Mock(return_value = eval(self.getFixture('valid_fixture').getvalue()))
+
+        self.collector.collect()
+
+        metrics = {
+            'test_group.test_name_1.state': 20,
+            'test_group.test_name_1.uptime':  5,
+            'test_group.test_name_2.state': 200,
+            'test_group.test_name_2.uptime': 500
+        }
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+################################################################################
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
In this pull request: a collector for supervisord (http://supervisord.org/) with relevant unit tests and documentation. I started with only a handful of stats ("state" and "uptime") and support for both the default unix socket-based and HTTP-based XML-RPC servers that supervisor can run. Those cover our team's basic needs for now and it should be straightforward to extend if needed.
