### PR TITLE
load collector module directly using imp.load_module

### DIFF
--- a/src/diamond/_collectors/__init__.py
+++ b/src/diamond/_collectors/__init__.py
@@ -1,0 +1,1 @@
+# a placeholder package for dymanic loaded collector modules.

--- a/src/diamond/util.py
+++ b/src/diamond/util.py
@@ -41,8 +41,9 @@ def load_class_from_name(fqcn):
     paths = fqcn.split('.')
     modulename = '.'.join(paths[:-1])
     classname = paths[-1]
-    # Import the module
-    __import__(modulename, globals(), locals(), ['*'])
+    if modulename not in sys.modules:
+        # Import the module
+        __import__(modulename, globals(), locals(), ['*'])
     # Get the class
     cls = getattr(sys.modules[modulename], classname)
     # Check cls


### PR DESCRIPTION
Fix #432.

Unlike `__import__`, `imp.load_module` can specify the file to load and
customize the full module name in `sys.modules`.  So it will not
conflict with system wide modules in site-packages.

It works in my environment:

```
hongqn@sa ~/diamond $ bin/diamond -f -l --skip-pidfile --skip-fork -c /etc/diamond/diamond-debug.conf -r /home/hongqn/puppet/modules/scribe/files/diamond/scribe.py
[2013-09-10 15:42:32,460] [MainThread] Changed UID: 2002 (diamond) GID: 2002 (diamond).
[2013-09-10 15:42:32,461] [MainThread] Loaded Handler: diamond.handler.null.NullHandler
[2013-09-10 15:42:32,465] [MainThread] Loading Collectors from: /home/hongqn/puppet/modules/scribe/files/diamond
[2013-09-10 15:42:32,472] [MainThread] Loaded Module: scribe
[2013-09-10 15:42:32,472] [MainThread] Loaded Collector: diamond._collectors.scribe.ScribeCollector
[2013-09-10 15:42:32,472] [MainThread] Initialized Collector: ScribeCollector
[2013-09-10 15:42:32,472] [MainThread] Scheduled task: ScribeCollector
[2013-09-10 15:42:32,473] [MainThread] Started task scheduler.
[2013-09-10 15:42:33,474] [Thread-1] Collecting data from: ScribeCollector
[2013-09-10 15:42:33,474] [MainThread] Stopping task scheduler.
[2013-09-10 15:42:33,476] [Thread-1] Process: servers.sa.ScribeCollector.queue_size 0 1378798953
[2013-09-10 15:42:33,476] [MainThread] Stopped task scheduler.
[2013-09-10 15:42:33,476] [MainThread] Exiting.
```
