### PR TITLE
Fixed nameclash with mysql-connector-python. The fix makes

### DIFF
--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -132,8 +132,9 @@ class Server(object):
         # Verify the path is valid
         if not os.path.isdir(path):
             return
-        # Add path to the system path
-        sys.path.append(path)
+        # Add path to the system path, to avoid name clashes
+        # with mysql-connector for example ...
+        sys.path.insert(1,path)
         # Load all the files in path
         for f in os.listdir(path):
             # Are we a directory? If so process down the tree


### PR DESCRIPTION
Fixed nameclash with mysql-connector-python. The fix makes module directory (collectors_path) higher priority over
site-packages.

If mysql-connector-python any MySQL-python is installed, the diamond silently tries to load mysql-connector-python's "mysql", which will make the module not get registered. 

Without the fix: 
[2013-09-10 17:06:50,804] [MainThread] Loading Collectors from: /usr/share/diamond/collectors/mysql
[2013-09-10 17:06:50,810] [MainThread] Loaded Module: mysql55
[2013-09-10 17:06:50,810] [MainThread] Loaded Collector: mysql55.MySQLPerfCollector
[2013-09-10 17:06:50,810] [MainThread] Loaded Module: mysql
[2013-09-10 17:06:50,810] [MainThread] Loading Collectors from: /usr/share/diamond/collectors/mysql/test
[2013-09-10 17:06:50,811] [MainThread] Loading Collectors from: /usr/share/diamond/collectors/loadavg
[2013-09-10 17:06:50,814] [MainThread] Loaded Module: loadavg

With the fix: 
[2013-09-10 17:07:11,296] [MainThread] Loading Collectors from: /usr/share/diamond/collectors/mysql
[2013-09-10 17:07:11,308] [MainThread] Loaded Module: mysql55
[2013-09-10 17:07:11,309] [MainThread] Loaded Collector: mysql55.MySQLPerfCollector
[2013-09-10 17:07:11,309] [MainThread] Loaded Module: mysql
[2013-09-10 17:07:11,309] [MainThread] Loaded Collector: mysql.MySQLCollector
[2013-09-10 17:07:11,310] [MainThread] Loading Collectors from: /usr/share/diamond/collectors/mysql/test
[2013-09-10 17:07:11,310] [MainThread] Loading Collectors from: /usr/share/diamond/collectors/loadavg
[2013-09-10 17:07:11,311] [MainThread] Loaded Module: loadavg
