### PR TITLE
Adds nfs client collector NfsCollector based on NfsdCollector

### DIFF
--- a/src/collectors/nfs/nfs.py
+++ b/src/collectors/nfs/nfs.py
@@ -1,0 +1,223 @@
+# coding=utf-8
+
+"""
+The NfsCollector collects nfs utilization metrics using /proc/net/rpc/nfs.
+
+#### Dependencies
+
+ * /proc/net/rpc/nfs
+
+"""
+
+import diamond.collector
+import os
+
+
+class NfsCollector(diamond.collector.Collector):
+
+    PROC = '/proc/net/rpc/nfs'
+
+    def get_default_config_help(self):
+        config_help = super(NfsCollector, self).get_default_config_help()
+        config_help.update({
+        })
+        return config_help
+
+    def get_default_config(self):
+        """
+        Returns the default collector settings
+        """
+        config = super(NfsCollector, self).get_default_config()
+        config.update({
+            'enabled':  False,
+            'path':     'nfs'
+        })
+        return config
+
+    def collect(self):
+        """
+        Collect stats
+        """
+        if os.access(self.PROC, os.R_OK):
+
+            results = {}
+            # Open file
+            file = open(self.PROC)
+
+            for line in file:
+                line = line.split()
+
+                if line[0] == 'net':
+                    results['net.packets'] = line[1]
+                    results['net.udpcnt'] = line[2]
+                    results['net.tcpcnt'] = line[3]
+                    results['net.tcpconn'] = line[4]
+                elif line[0] == 'rpc':
+                    results['rpc.calls'] = line[1]
+                    results['rpc.retrans'] = line[2]
+                    results['rpc.authrefrsh'] = line[3]
+                elif line[0] == 'proc2':
+                    results['v2.null'] = line[1]
+                    results['v2.getattr'] = line[2]
+                    results['v2.setattr'] = line[3]
+                    results['v2.root'] = line[4]
+                    results['v2.lookup'] = line[5]
+                    results['v2.readlink'] = line[6]
+                    results['v2.read'] = line[7]
+                    results['v2.wrcache'] = line[8]
+                    results['v2.write'] = line[9]
+                    results['v2.create'] = line[10]
+                    results['v2.remove'] = line[11]
+                    results['v2.rename'] = line[12]
+                    results['v2.link'] = line[13]
+                    results['v2.symlink'] = line[14]
+                    results['v2.mkdir'] = line[15]
+                    results['v2.rmdir'] = line[16]
+                    results['v2.readdir'] = line[17]
+                    results['v2.fsstat'] = line[18]
+                elif line[0] == 'proc3':
+                    results['v3.null'] = line[1]
+                    results['v3.getattr'] = line[2]
+                    results['v3.setattr'] = line[3]
+                    results['v3.lookup'] = line[4]
+                    results['v3.access'] = line[5]
+                    results['v3.readlink'] = line[6]
+                    results['v3.read'] = line[7]
+                    results['v3.write'] = line[8]
+                    results['v3.create'] = line[9]
+                    results['v3.mkdir'] = line[10]
+                    results['v3.symlink'] = line[11]
+                    results['v3.mknod'] = line[12]
+                    results['v3.remove'] = line[13]
+                    results['v3.rmdir'] = line[14]
+                    results['v3.rename'] = line[15]
+                    results['v3.link'] = line[16]
+                    results['v3.readdir'] = line[17]
+                    results['v3.readdirplus'] = line[18]
+                    results['v3.fsstat'] = line[19]
+                    results['v3.fsinfo'] = line[20]
+                    results['v3.pathconf'] = line[21]
+                    results['v3.commit'] = line[22]
+                elif line[0] == 'proc4':
+                    results['v4.null'] = line[1]
+                    results['v4.read'] = line[2]
+                    results['v4.write'] = line[3]
+                    results['v4.commit'] = line[4]
+                    results['v4.open'] = line[5]
+                    results['v4.open_conf'] = line[6]
+                    results['v4.open_noat'] = line[7]
+                    results['v4.open_dgrd'] = line[8]
+                    results['v4.close'] = line[9]
+                    results['v4.setattr'] = line[10]
+                    results['v4.fsinfo'] = line[11]
+                    results['v4.renew'] = line[12]
+                    results['v4.setclntid'] = line[13]
+                    results['v4.confirm'] = line[14]
+                    results['v4.lock'] = line[15]
+                    results['v4.lockt'] = line[16]
+                    results['v4.locku'] = line[17]
+                    results['v4.access'] = line[18]
+                    results['v4.getattr'] = line[19]
+                    results['v4.lookup'] = line[20]
+                    results['v4.lookup_root'] = line[21]
+                    results['v4.remove'] = line[22]
+                    results['v4.rename'] = line[23]
+                    results['v4.link'] = line[24]
+                    results['v4.symlink'] = line[25]
+                    results['v4.create'] = line[26]
+                    results['v4.pathconf'] = line[27]
+                    results['v4.statfs'] = line[28]
+                    results['v4.readlink'] = line[29]
+                    results['v4.readdir'] = line[30]
+                    try:
+                        results['v4.server_caps'] = line[31]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.delegreturn'] = line[32]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.getacl'] = line[33]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.setacl'] = line[34]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.fs_locations'] = line[35]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.rel_lkowner'] = line[36]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.exchange_id'] = line[37]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.create_ses'] = line[38]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.destroy_ses'] = line[39]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.sequence'] = line[40]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.get_lease_t'] = line[41]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.reclaim_comp'] = line[42]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.layoutget'] = line[43]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.layoutcommit'] = line[44]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.layoutreturn'] = line[45]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.getdevlist'] = line[46]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.getdevinfo'] = line[47]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.ds_write'] = line[48]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.ds_commit'] = line[49]
+                    except IndexError:
+                        pass
+                    try:
+                        results['v4.getdevlist'] = line[50]
+                    except IndexError:
+                        pass
+
+            # Close File
+            file.close()
+
+            for stat in results.keys():
+                metric_name = '.' + stat
+                metric_value = long(float(results[stat]))
+                metric_value = self.derivative(metric_name, metric_value)
+                self.publish(metric_name, metric_value)
+            return True
+
+        return False

--- a/src/collectors/nfs/test/testnfs.py
+++ b/src/collectors/nfs/test/testnfs.py
@@ -1,0 +1,113 @@
+#!/usr/bin/python
+# coding=utf-8
+################################################################################
+
+from test import CollectorTestCase
+from test import get_collector_config
+from test import unittest
+from mock import Mock
+from mock import patch
+
+try:
+    from cStringIO import StringIO
+    StringIO  # workaround for pyflakes issue #13
+except ImportError:
+    from StringIO import StringIO
+
+from diamond.collector import Collector
+from nfs import NfsCollector
+
+################################################################################
+
+
+class TestNfsCollector(CollectorTestCase):
+    def setUp(self):
+        config = get_collector_config('NfsCollector', {
+            'interval': 1
+        })
+
+        self.collector = NfsCollector(config, None)
+
+    def test_import(self):
+        self.assertTrue(NfsCollector)
+
+    @patch('__builtin__.open')
+    @patch('os.access', Mock(return_value=True))
+    @patch.object(Collector, 'publish')
+    def test_should_open_proc_stat(self, publish_mock, open_mock):
+        open_mock.return_value = StringIO('')
+        self.collector.collect()
+        open_mock.assert_called_once_with('/proc/net/rpc/nfs')
+
+    @patch.object(Collector, 'publish')
+    def test_should_work_with_real_data(self, publish_mock):
+        NfsCollector.PROC = self.getFixturePath('proc_nfs_1')
+        self.collector.collect()
+
+        self.assertPublishedMany(publish_mock, {})
+
+        NfsCollector.PROC = self.getFixturePath('proc_nfs_2')
+        self.collector.collect()
+
+        metrics = {
+            '.input_output.bytes-read': 3139369493.0,
+            '.input_output.bytes-written': 15691669.0,
+            '.net.cnt': 14564086.0,
+            '.net.tcpcnt': 14562696.0,
+            '.net.tcpconn': 30773.0,
+            '.read-ahead.10-pct': 8751152.0,
+            '.read-ahead.cache-size': 32.0,
+            '.read-ahead.not-found': 18612.0,
+            '.reply_cache.misses': 71080.0,
+            '.reply_cache.nocache': 14491982.0,
+            '.rpc.calls': 14563007.0,
+            '.threads.10-20-pct': 22163.0,
+            '.threads.100-pct': 22111.0,
+            '.threads.20-30-pct': 8448.0,
+            '.threads.30-40-pct': 1642.0,
+            '.threads.50-60-pct': 5072.0,
+            '.threads.60-70-pct': 1210.0,
+            '.threads.70-80-pct': 3889.0,
+            '.threads.80-90-pct': 2654.0,
+            '.threads.fullcnt': 1324492.0,
+            '.threads.threads': 8.0,
+            '.v2.null': 8.0,
+            '.v3.access': 136921.0,
+            '.v3.commit': 635.0,
+            '.v3.create': 1655.0,
+            '.v3.fsinfo': 11.0,
+            '.v3.fsstat': 34450.0,
+            '.v3.getattr': 724974.0,
+            '.v3.lookup': 213165.0,
+            '.v3.null': 8.0,
+            '.v3.read': 8761683.0,
+            '.v3.readdir': 11295.0,
+            '.v3.readdirplus': 132298.0,
+            '.v3.remove': 1488.0,
+            '.v3.write': 67937.0,
+            '.v4.compound': 4476320.0,
+            '.v4.null': 18.0,
+            '.v4.access': 2083822.0,
+            '.v4.close': 34801.0,
+            '.v4.commit': 3955.0,
+            '.v4.getattr': 2302848.0,
+            '.v4.lookup': 68501.0,
+            '.v4.open': 34847.0,
+            '.v4.open_conf': 29002.0,
+            '.v4.read': 8030.0,
+            '.v4.readdir': 272.0,
+            '.v4.remove': 7802.0,
+            '.v4.renew': 28594.0,
+            '.v4.setattr': 7870.0,
+            '.v4.setclntid': 6226.0,
+            '.v4.write': 76562.0
+    	}
+
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+################################################################################
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I had a look at the nfsd collector, and created one for nfs clients. I'm using CentOS and RHEL 5/6 that I've based the metrics on what nfsstat pulls out of /proc/net/rpc/nfs. The ordering in RHEL's /proc/net/rpc/nfs file is quite different from the nfsd collector already included in Diamond -- not sure what OS it was written for.

I've added a bunch of try blocks for nfs v4 stats greater than 30. I've yet to run across a server that doesn't at least have the first 30. 

The test script nfstest.py definitely needs some review. I've only tweaked what I found in the nfsd test script, so I am not entirely sure if the metric values will still be accurate for nfs clients.
