### PR TITLE
removed auto-enable for mountstats collector

### DIFF
--- a/src/collectors/mountstats/mountstats.py
+++ b/src/collectors/mountstats/mountstats.py
@@ -80,7 +80,7 @@ class MountStatsCollector(diamond.collector.Collector):
     def get_default_config(self):
         config = super(MountStatsCollector, self).get_default_config()
         config.update({
-            'enabled': 'True',
+            'enabled': 'False',
             'exclude_filters': [],
             'path': 'mountstats',
             'method': 'Threaded'


### PR DESCRIPTION
After upgrading Diamond the logging started filling with "Cannot read path /proc/self/mountstats" errors, caused by the mountstat collector. I guess the enabled=True configuration was a development setting and not meant to be part of the master configuration?
