### PR TITLE
Skip collectors and handlers with syntax errors.

### DIFF
--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -106,7 +106,7 @@ class Server(object):
                 # Initialize Handler class
                 self.handlers.append(cls(handler_config))
 
-            except ImportError:
+            except (ImportError, SyntaxError):
                 # Log Error
                 self.log.debug("Failed to load handler %s. %s", h,
                                traceback.format_exc())
@@ -198,7 +198,7 @@ class Server(object):
                 try:
                     # Import the module
                     mod = __import__(modname, globals(), locals(), ['*'])
-                except ImportError:
+                except (ImportError, SyntaxError):
                     # Log error
                     self.log.error("Failed to import module: %s. %s", modname,
                                    traceback.format_exc())


### PR DESCRIPTION
As per https://github.com/BrightcoveOS/Diamond/wiki/Installation, Diamond
supports Python 2.4+, but the kafka and jcollectd collectors break
compatibility. This change handles treats syntax errors the same as import
errors so that the server can run without incompatible collectors and handlers
on systems with older versions of Python.

Caveat: this fix only works if the core server code keeps compatibility with
Python 2.4.

Addresses BrightcoveOS/Diamond#444
