### PR TITLE
nginx: fix log error msg text

### DIFF
--- a/src/collectors/nginx/nginx.py
+++ b/src/collectors/nginx/nginx.py
@@ -82,7 +82,7 @@ class NginxCollector(diamond.collector.Collector):
                     self.publish_gauge('act_writes', int(m.group('writing')))
                     self.publish_gauge('act_waits', int(m.group('waiting')))
         except IOError, e:
-            self.log.error("Unable to open http://%s:%i:%s",
+            self.log.error("Unable to open http://%s:%i%s",
                            self.config['req_host'],
                            int(self.config['req_port']),
                            self.config['req_path'])


### PR DESCRIPTION
Fixes the nginx collector log error message. Not a biggie but the error message got me confused when I was troubleshooting this collector.
