### PR TITLE
Enable default database for _connect()

### DIFF
--- a/src/collectors/postgres/postgres.py
+++ b/src/collectors/postgres/postgres.py
@@ -112,6 +112,8 @@ class PostgresqlCollector(diamond.collector.Collector):
 
         if database:
             conn_args['database'] = database
+        else:
+            conn_args['database'] = 'postgres'
 
         conn = psycopg2.connect(**conn_args)
 


### PR DESCRIPTION
In the event you connect with a user that doesn't have it's own
database, set the default to be 'postgres' to enable _get_db_names()
to be able to collect the list of databases.
