### PR TITLE
Allow collectors to pass absolute metric paths

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -14,6 +14,10 @@ import time
 
 from diamond.metric import Metric
 
+# Collectors may prefix metric names with this to mark them as
+# absolute (i.e. not to be prepended with hostname)
+ABSOLUTE_PATH_MARKER = "___"
+
 # Detect the architecture of the system and set the counters for MAX_VALUES
 # appropriately. Otherwise, rolling over counters will cause incorrect or
 # negative values.
@@ -266,6 +270,11 @@ class Collector(object):
             virtual machine and should have a different
             root prefix.
         """
+
+        # If the path is absolute, do not prepend anything to it
+        if name.startswith(ABSOLUTE_PATH_MARKER):
+            return name[len(ABSOLUTE_PATH_MARKER):]
+
         if 'path' in self.config:
             path = self.config['path']
         else:


### PR DESCRIPTION
This is a quick hack, it might be cleaner to do something with an explicit flag to publish_metrics, but I was going for the least invasive change.

They may do it by starting metric paths with
collectors.ABSOLUTE_PATH_MARKER.

This is useful for monitoring things which are
not associated with a particular host, such
as cluster state in a distributed system.
