### PR TITLE
Allow -r to run without a full path.

### DIFF
--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -352,8 +352,15 @@ class Server(object):
         self.load_config()
 
         # Load collectors
-        self.load_include_path(os.path.dirname(file))
-        collectors = self.load_collectors(os.path.dirname(file), file)
+        if os.path.dirname(file) == '':
+            tmp_path = self.config['server']['collectors_path']
+        else:
+            tmp_path = os.path.dirname(file)
+        self.load_include_path(tmp_path)
+        collectors = self.load_collectors(tmp_path, file)
+        for item in collectors.keys():
+            if not item.lower() in file.lower():
+                del collectors[item]
 
         # Setup Collectors
         for cls in collectors.values():


### PR DESCRIPTION
When running diamond in the foreground, it's useful to test single collectors. This functionality already exists, but to extend it:

diamond -f -l -r memorycollector
Will now default to the configured collectors_path and find only collectors that match the name specified.
In this example, if the default collector path is /usr/lib/diamond/collectors and we pass in -r memorycollector, the run_one function will collect all the collectors in /usr/lib/diamond/collectors, remove files that don't match with the name specified in the -r directive, and then execute only those files.
