### PR TITLE
Add rudimentary support for Riemann TTL attribute.

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -222,6 +222,9 @@ class Collector(object):
             # Default Poll Interval (seconds)
             'interval': 300,
 
+            # Default Event TTL (interval multiplier)
+            'ttl_multiplier': 2,
+
             # Default collector threading model
             'method': 'Sequential',
 
@@ -324,10 +327,13 @@ class Collector(object):
         # Get metric Path
         path = self.get_metric_path(name, instance=instance)
 
+        # Get metric TTL
+        ttl = float(self.config['interval']) * float(self.config['ttl_multiplier'])
+
         # Create Metric
         metric = Metric(path, value, raw_value=raw_value, timestamp=None,
                         precision=precision, host=self.get_hostname(),
-                        metric_type=metric_type)
+                        metric_type=metric_type, ttl=ttl)
 
         # Publish Metric
         self.publish_metric(metric)

--- a/src/diamond/handler/riemann.py
+++ b/src/diamond/handler/riemann.py
@@ -103,6 +103,7 @@ class RiemannHandler(Handler):
             'service': path,
             'time': metric.timestamp,
             'metric': float(metric.value),
+            'ttl': metric.ttl,
         }
 
     def _close(self):

--- a/src/diamond/metric.py
+++ b/src/diamond/metric.py
@@ -11,7 +11,7 @@ class Metric(object):
     _METRIC_TYPES = ['COUNTER', 'GAUGE']
 
     def __init__(self, path, value, raw_value=None, timestamp=None, precision=0,
-                 host=None, metric_type='COUNTER'):
+                 host=None, metric_type='COUNTER', ttl=None):
         """
         Create new instance of the Metric class
 
@@ -58,6 +58,7 @@ class Metric(object):
         self.precision = precision
         self.host = host
         self.metric_type = metric_type
+        self.ttl = ttl
 
     def __repr__(self):
         """


### PR DESCRIPTION
Riemann supports the ability to expire metrics that have lingered too long without being replaced by fresh ones. This is useful for things like detecting failures. This is set to double the interval by default, but the multiplier is configurable on a per-collector basis.
