### PR TITLE
mysql collector now accepts any case version of 'true' for configuration switches

### DIFF
--- a/src/collectors/mysql/mysql.py
+++ b/src/collectors/mysql/mysql.py
@@ -320,7 +320,7 @@ class MySQLCollector(diamond.collector.Collector):
             except:
                 pass
 
-        if self.config['master'] == 'True':
+        if self.config['master'].lower() == 'true':
             metrics['master'] = {}
             try:
                 rows = self.get_db_master_status()
@@ -336,7 +336,7 @@ class MySQLCollector(diamond.collector.Collector):
                 self.log.error('MySQLCollector: Couldnt get master status')
                 pass
 
-        if self.config['slave'] == 'True':
+        if self.config['slave'].lower() == 'true':
             metrics['slave'] = {}
             try:
                 rows = self.get_db_slave_status()
@@ -352,7 +352,7 @@ class MySQLCollector(diamond.collector.Collector):
                 self.log.error('MySQLCollector: Couldnt get slave status')
                 pass
 
-        if self.config['innodb'] == 'True':
+        if self.config['innodb'].lower() == 'true':
             metrics['innodb'] = {}
             innodb_status_timer = time.time()
             try:


### PR DESCRIPTION
Had fun working out why my mysql server wasn't collecting metrics for "SHOW SLAVE STATUS". Turns out it was because I had the following in my config:

slave = true

It was only checking for:

slave = True
