### PR TITLE
Improved exception handling for Elasticsearch collector

### DIFF
--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -53,7 +53,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
             self.config['host'], int(self.config['port']), path)
         try:
             response = urllib2.urlopen(url)
-        except urllib2.HTTPError, err:
+        except urllib2.URLError, err:
             self.log.error("%s: %s", url, err)
             return False
 


### PR DESCRIPTION
Catching HTTPError only works for HTTP errors. Connectivity issues (during ES restart) trigger an URLError, not catched thus crashing the collector.

As HTTPError is a subclass of URLError, this change will deal with more failure situations.
