### PR TITLE
Broader exception catching for ES collector http call

### DIFF
--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -53,7 +53,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
             self.config['host'], int(self.config['port']), path)
         try:
             response = urllib2.urlopen(url)
-        except urllib2.URLError, err:
+        except Exception, err:
             self.log.error("%s: %s", url, err)
             return False
 


### PR DESCRIPTION
Hi,

Even catching URLError was not enough. Collecting metrics during ES restart sometimes hits the httplib.BadStatusLine exception (subclass of http.HTTPException).

But to be sure I changed the except to any Exception. Let's get this over with :-)

```
[2013-12-16 16:16:34,921] [Thread-1] Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/diamond/collector.py", line 390, in _run
    self.collect()
  File "/usr/share/diamond/collectors/elasticsearch/elasticsearch.py", line 227, in collect
    + 'indexing=true&get=true&search=true')
  File "/usr/share/diamond/collectors/elasticsearch/elasticsearch.py", line 55, in _get
    response = urllib2.urlopen(url)
  File "/usr/lib64/python2.6/urllib2.py", line 126, in urlopen
    return _opener.open(url, data, timeout)
  File "/usr/lib64/python2.6/urllib2.py", line 391, in open
    response = self._open(req, data)
  File "/usr/lib64/python2.6/urllib2.py", line 409, in _open
    '_open', req)
  File "/usr/lib64/python2.6/urllib2.py", line 369, in _call_chain
    result = func(*args)
  File "/usr/lib64/python2.6/urllib2.py", line 1190, in http_open
    return self.do_open(httplib.HTTPConnection, req)
  File "/usr/lib64/python2.6/urllib2.py", line 1163, in do_open
    r = h.getresponse()
  File "/usr/lib64/python2.6/httplib.py", line 990, in getresponse
    response.begin()
  File "/usr/lib64/python2.6/httplib.py", line 391, in begin
    version, status, reason = self._read_status()
  File "/usr/lib64/python2.6/httplib.py", line 355, in _read_status
    raise BadStatusLine(line)
BadStatusLine
```
