### PR TITLE
tsdb.py: format metrics more idiomatically

### DIFF
--- a/src/diamond/handler/tsdb.py
+++ b/src/diamond/handler/tsdb.py
@@ -60,6 +60,8 @@ class TSDBHandler(Handler):
         self.host = self.config['host']
         self.port = int(self.config['port'])
         self.timeout = int(self.config['timeout'])
+        self.metric_format  = str(self.config['format'])
+        self.tags    = str(self.config['tags'])
 
         # Connect
         self._connect()
@@ -74,6 +76,8 @@ class TSDBHandler(Handler):
             'host': '',
             'port': '',
             'timeout': '',
+            'format': '',
+            'tags': '',
         })
 
         return config
@@ -88,6 +92,8 @@ class TSDBHandler(Handler):
             'host': '',
             'port': 1234,
             'timeout': 5,
+            'format': '{Collector}.{Metric} {timestamp} {value} hostname={host} {tags}',
+            'tags': '',
         })
 
         return config
@@ -102,8 +108,18 @@ class TSDBHandler(Handler):
         """
         Process a metric by sending it to TSDB
         """
+
+        metric_str = self.metric_format.format(
+                Collector = metric.getCollectorPath(), 
+                Path      = metric.path,
+                Metric    = metric.getMetricPath(),
+                host      = metric.host,
+                timestamp = metric.timestamp,
+                value     = metric.value,
+                tags      = self.tags
+        )
         # Just send the data as a string
-        self._send("put " + str(metric))
+        self._send("put " + str(metric_str) + "\n" )
 
     def _send(self, data):
         """


### PR DESCRIPTION
allow metric format to be user controllable
set default tag hostname with metric host
allow tags to be configured and passed through
