### PR TITLE
Throttle logging

### DIFF
--- a/src/diamond/handler/Handler.py
+++ b/src/diamond/handler/Handler.py
@@ -4,6 +4,7 @@ import logging
 import threading
 import traceback
 from configobj import ConfigObj
+import time
 
 
 class Handler(object):
@@ -27,6 +28,8 @@ class Handler(object):
         # Load in user
         self.config.merge(config)
 
+        self._errors = {}
+
         # Initialize Lock
         self.lock = threading.Lock()
 
@@ -36,6 +39,8 @@ class Handler(object):
         """
         return {
             'get_default_config_help': 'get_default_config_help',
+            'server_error_interval': ('How frequently to send repeated server '
+                                      'errors'),
         }
 
     def get_default_config(self):
@@ -44,6 +49,7 @@ class Handler(object):
         """
         return {
             'get_default_config': 'get_default_config',
+            'server_error_interval': 120,
         }
 
     def _process(self, metric):
@@ -89,3 +95,44 @@ class Handler(object):
         Optional: Should be overridden in subclasses
         """
         pass
+
+    def _throttle_error(self, msg, *args, **kwargs):
+        """
+        Avoids sending errors repeatedly. Waits at least
+        `self.server_error_interval` seconds before sending the same error
+        string to the error logging facility. If not enough time has passed,
+        it calls `log.debug` instead
+
+        Receives the same parameters as `Logger.error` an passes them on to the
+        selected logging function, but ignores all parameters but the main
+        message string when checking the last emission time.
+
+        :returns: the return value of `Logger.debug` or `Logger.error`
+        """
+        now = time.time()
+        if msg in self._errors:
+            if ((now - self._errors[msg]) >=
+                    self.server_error_interval):
+                fn = self.log.error
+                self._errors[msg] = now
+            else:
+                fn = self.log.debug
+        else:
+            self._errors[msg] = now
+            fn = self.log.error
+
+        return fn(msg, *args, **kwargs)
+
+    def _reset_errors(self, msg=None):
+        """
+        Resets the logging throttle cache, so the next error is emitted
+        regardless of the value in `self.server_error_interval`
+
+        :param msg: if present, only this key is reset. Otherwise, the whole
+            cache is cleaned.
+        """
+        if msg is not None and msg in self._errors:
+            del self._errors[msg]
+        else:
+            self._errors = {}
+


### PR DESCRIPTION
This stops the graphite handler from killing the logging facility if the graphite server is down for a few minutes (or the connection fails because of any other network problem) and thousands of metrics fail to be sent.

This code should probably be moved to the base `Handler` class so it can be reused by other handlers
