### PR TITLE
Add simple tokumx collector (based off mongodb collector)

### DIFF
--- a/src/collectors/tokumx/test/testtokumx.py
+++ b/src/collectors/tokumx/test/testtokumx.py
@@ -11,7 +11,7 @@ from mock import patch
 from mock import call
 
 from diamond.collector import Collector
-from mongodb import MongoDBCollector
+from tokumx import TokuMXCollector
 
 ################################################################################
 
@@ -26,17 +26,17 @@ def run_only_if_pymongo_is_available(func):
     return run_only(func, pred)
 
 
-class TestMongoDBCollector(CollectorTestCase):
+class TestTokuMXCollector(CollectorTestCase):
     def setUp(self):
-        config = get_collector_config('MongoDBCollector', {
+        config = get_collector_config('TokuMXCollector', {
             'host': 'localhost:27017',
             'databases': '^db',
         })
-        self.collector = MongoDBCollector(config, None)
+        self.collector = TokuMXCollector(config, None)
         self.connection = MagicMock()
 
     def test_import(self):
-        self.assertTrue(MongoDBCollector)
+        self.assertTrue(TokuMXCollector)
 
     @run_only_if_pymongo_is_available
     @patch('pymongo.Connection')
@@ -142,15 +142,15 @@ class TestMongoDBCollector(CollectorTestCase):
 
 class TestMongoMultiHostDBCollector(CollectorTestCase):
     def setUp(self):
-        config = get_collector_config('MongoDBCollector', {
+        config = get_collector_config('TokuMXCollector', {
             'hosts': ['localhost:27017', 'localhost:27057'],
             'databases': '^db',
         })
-        self.collector = MongoDBCollector(config, None)
+        self.collector = TokuMXCollector(config, None)
         self.connection = MagicMock()
 
     def test_import(self):
-        self.assertTrue(MongoDBCollector)
+        self.assertTrue(TokuMXCollector)
 
     @run_only_if_pymongo_is_available
     @patch('pymongo.Connection')

--- a/src/collectors/tokumx/tokumx.py
+++ b/src/collectors/tokumx/tokumx.py
@@ -27,14 +27,14 @@ except ImportError:
     ReadPreference = None
 
 
-class MongoDBCollector(diamond.collector.Collector):
+class TokuMXCollector(diamond.collector.Collector):
 
     def __init__(self, *args, **kwargs):
         self.__totals = {}
-        super(MongoDBCollector, self).__init__(*args, **kwargs)
+        super(TokuMXCollector, self).__init__(*args, **kwargs)
 
     def get_default_config_help(self):
-        config_help = super(MongoDBCollector, self).get_default_config_help()
+        config_help = super(TokuMXCollector, self).get_default_config_help()
         config_help.update({
             'hosts': 'Array of hostname(:port) elements to get metrics from'
                      'Set an alias by prefixing host:port with alias@',
@@ -59,7 +59,7 @@ class MongoDBCollector(diamond.collector.Collector):
         """
         Returns the default collector settings
         """
-        config = super(MongoDBCollector, self).get_default_config()
+        config = super(TokuMXCollector, self).get_default_config()
         config.update({
             'path':      'mongo',
             'hosts':     ['localhost'],


### PR DESCRIPTION
TokuMX is a MongoDB fork based on TokuTek's fractal tree data structure. This fork add a `engineStatus` command that gives insight into many internal metrics of the database that may be helpful in diagnosing problems and monitoring the overall health of the system.

This is a collector that adds metrics specific to tokumx. I have basically taken the mongodb collector and simply added the results of `db.engineStatus()` to the `db.serverStatus()`. 
Please refer to the user guide at [TokuMX website](http://www.tokutek.com/products/tokumx-for-mongodb/) for more information.
