### PR TITLE
Add additional metrics to Apache httpd collector

### DIFF
--- a/src/collectors/httpd/httpd.py
+++ b/src/collectors/httpd/httpd.py
@@ -56,9 +56,6 @@ class HttpdCollector(diamond.collector.Collector):
         for nickname in self.urls.keys():
             url = self.urls[nickname]
 
-            metrics = ['ReqPerSec', 'BytesPerSec', 'BytesPerReq',
-                       'BusyWorkers', 'IdleWorkers', 'Total Accesses']
-
             try:
                 while True:
 
@@ -103,16 +100,52 @@ class HttpdCollector(diamond.collector.Collector):
                     if m:
                         k = m.group(1)
                         v = m.group(2)
-                        if k in metrics:
-                            # Get Metric Name
-                            metric_name = "%s" % re.sub('\s+', '', k)
 
-                            # Prefix with the nickname?
-                            if len(nickname) > 0:
-                                metric_name = nickname + '.' + metric_name
+                        # IdleWorkers gets determined from the scoreboard
+                        if k == 'IdleWorkers':
+                            continue
 
-                            # Get Metric Value
-                            metric_value = "%d" % float(v)
+                        if k == 'Scoreboard':
+                            for sb_kv in self._parseScoreboard(v):
+                                self._publish(nickname, sb_kv[0], sb_kv[1])
+                        else:
+                            self._publish(nickname,k,v)
 
-                            # Publish Metric
-                            self.publish(metric_name, metric_value)
+    def _publish(self, nickname, key, value):
+
+        metrics = ['ReqPerSec', 'BytesPerSec', 'BytesPerReq',
+                'BusyWorkers', 'Total Accesses', 'IdleWorkers',
+                'StartingWorkers', 'ReadingWorkers', 'WritingWorkers',
+                'KeepaliveWorkers', 'DnsWorkers', 'ClosingWorkers',
+                'LoggingWorkers', 'FinishingWorkers',
+                'CleanupWorkers']
+
+        if key in metrics:
+            # Get Metric Name
+            metric_name = "%s" % re.sub('\s+', '', key)
+
+            # Prefix with the nickname?
+            if len(nickname) > 0:
+                metric_name = nickname + '.' + metric_name
+
+            # Get Metric Value
+            metric_value = "%d" % float(value)
+
+            # Publish Metric
+            self.publish(metric_name, metric_value)
+
+    def _parseScoreboard(self, sb):
+
+        ret = []
+
+        ret.append( ('IdleWorkers',sb.count('_')) )
+        ret.append( ('ReadingWorkers',sb.count('R')) )
+        ret.append( ('WritingWorkers',sb.count('W')) )
+        ret.append( ('KeepaliveWorkers',sb.count('K')) )
+        ret.append( ('DnsWorkers',sb.count('D')) )
+        ret.append( ('ClosingWorkers',sb.count('C')) )
+        ret.append( ('LoggingWorkers',sb.count('L')) )
+        ret.append( ('FinishingWorkers',sb.count('G')) )
+        ret.append( ('CleanupWorkers',sb.count('I')) )
+
+        return ret

--- a/src/collectors/httpd/test/testhttpd.py
+++ b/src/collectors/httpd/test/testhttpd.py
@@ -84,6 +84,14 @@ class TestHttpdCollector(CollectorTestCase):
             'BytesPerReq': 204,
             'BusyWorkers': 6,
             'IdleWorkers': 4,
+            'WritingWorkers': 1,
+            'KeepaliveWorkers': 2,
+            'ReadingWorkers': 3,
+            'DnsWorkers': 0,
+            'ClosingWorkers': 0,
+            'LoggingWorkers': 0,
+            'FinishingWorkers': 0,
+            'CleanupWorkers': 0,
         })
 
     @patch.object(Collector, 'publish')
@@ -126,6 +134,14 @@ class TestHttpdCollector(CollectorTestCase):
             'BytesPerReq': 5418,
             'BusyWorkers': 9,
             'IdleWorkers': 0,
+            'WritingWorkers': 1,
+            'KeepaliveWorkers': 7,
+            'ReadingWorkers': 1,
+            'DnsWorkers': 0,
+            'ClosingWorkers': 0,
+            'LoggingWorkers': 0,
+            'FinishingWorkers': 0,
+            'CleanupWorkers': 0,
         }
         self.assertPublishedMany(publish_mock, metrics)
 
@@ -174,6 +190,14 @@ class TestHttpdCollector(CollectorTestCase):
             'nickname1.BytesPerReq': 5418,
             'nickname1.BusyWorkers': 9,
             'nickname1.IdleWorkers': 0,
+            'nickname1.WritingWorkers': 1,
+            'nickname1.KeepaliveWorkers': 7,
+            'nickname1.ReadingWorkers': 1,
+            'nickname1.DnsWorkers': 0,
+            'nickname1.ClosingWorkers': 0,
+            'nickname1.LoggingWorkers': 0,
+            'nickname1.FinishingWorkers': 0,
+            'nickname1.CleanupWorkers': 0,
 
             'nickname2.TotalAccesses': 8314,
             'nickname2.ReqPerSec': 0,
@@ -181,6 +205,14 @@ class TestHttpdCollector(CollectorTestCase):
             'nickname2.BytesPerReq': 5418,
             'nickname2.BusyWorkers': 9,
             'nickname2.IdleWorkers': 0,
+            'nickname2.WritingWorkers': 1,
+            'nickname2.KeepaliveWorkers': 7,
+            'nickname2.ReadingWorkers': 1,
+            'nickname2.DnsWorkers': 0,
+            'nickname2.ClosingWorkers': 0,
+            'nickname2.LoggingWorkers': 0,
+            'nickname2.FinishingWorkers': 0,
+            'nickname2.CleanupWorkers': 0,
         }
 
         self.setDocExample(collector=self.collector.__class__.__name__,
@@ -230,6 +262,14 @@ class TestHttpdCollector(CollectorTestCase):
             'BytesPerReq': 15403,
             'BusyWorkers': 1,
             'IdleWorkers': 17,
+            'WritingWorkers': 1,
+            'KeepaliveWorkers': 0,
+            'ReadingWorkers': 0,
+            'DnsWorkers': 0,
+            'ClosingWorkers': 0,
+            'LoggingWorkers': 0,
+            'FinishingWorkers': 0,
+            'CleanupWorkers': 0,
         }
         self.assertPublishedMany(publish_mock, metrics)
 


### PR DESCRIPTION
This allows the Apache httpd collector report additional metrics about
workers by parsing the "Scoreboard" from mod_status; previously, the
Scoreboard was ignored.

In addition to reporting "IdleWorkers", the collector now reports
metrics for: 'StartingWorkers', 'ReadingWorkers', 'WritingWorkers',
'KeepaliveWorkers', 'DnsWorkers', 'ClosingWorkers', 'LoggingWorkers',
'FinishingWorkers', and 'CleanupWorkers'
