### PR TITLE
make sure all of the needed fields are present

### DIFF
--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -209,7 +209,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
 
         #
         # filesystem (may not be present, depending on access restrictions)
-        if 'fs' in data:
+        if 'fs' in data and 'data' in data['fs'] and data['fs']['data']:
             fs_data = data['fs']['data'][0]
             self._add_metric(metrics, 'disk.reads.count', fs_data,
                              ['disk_reads'])


### PR DESCRIPTION
There has been a fix (587142501419279ee405fbf2c28d4913dcd0e9cd) to make sure older versions of elasticsearch that don't return the 'fs' field when permissions don't allow don't break the collector, but in 0.20 ES's behavior seems to be returning `{..., "fs": { "timestamp": xxxxxxx, data: [] }, ...}` instead.

I added a better ward to this to avoid index exceptions
