### PR TITLE
Add a 'collection_sample_rate' to the mongodb collector

### DIFF
--- a/src/collectors/mongodb/mongodb.py
+++ b/src/collectors/mongodb/mongodb.py
@@ -13,6 +13,7 @@ values are ignored.
 import diamond.collector
 from diamond.collector import str_to_bool
 import re
+import zlib
 
 try:
     import pymongo
@@ -26,8 +27,8 @@ try:
 except ImportError:
     ReadPreference = None
 
-
 class MongoDBCollector(diamond.collector.Collector):
+    MAX_CRC32 = 4294967295
 
     def __init__(self, *args, **kwargs):
         self.__totals = {}
@@ -47,6 +48,10 @@ class MongoDBCollector(diamond.collector.Collector):
             'ignore_collections': 'A regex of which collections to ignore.'
                                   ' MapReduce temporary collections (tmp.mr.*)'
                                   ' are ignored by default.',
+            'collection_sample_rate': 'Only send stats for a consistent subset of collections'
+                                    ' This is applied after collections are ignored via ignore_collections'
+                                    ' Sampling uses crc32 so it is consistent across replicas'
+                                    ' Value between 0 and 1. Default is 1',
             'network_timeout': 'Timeout for mongodb connection (in seconds).'
                                ' There is no timeout by default.',
             'simple': 'Only collect the same metrics as mongostat.',
@@ -69,7 +74,8 @@ class MongoDBCollector(diamond.collector.Collector):
             'ignore_collections': '^tmp\.mr\.',
             'network_timeout': None,
             'simple': 'False',
-            'translate_collections': 'False'
+            'translate_collections': 'False',
+            'collection_sample_rate': 1
         })
         return config
 
@@ -88,6 +94,11 @@ class MongoDBCollector(diamond.collector.Collector):
         if self.config['network_timeout']:
             self.config['network_timeout'] = int(
                 self.config['network_timeout'])
+
+        # convert collection_sample_rate to float
+        if self.config['collection_sample_rate']:
+            self.config['collection_sample_rate'] = float(
+                self.config['collection_sample_rate'])
 
         # use auth if given
         if 'user' in self.config:
@@ -148,6 +159,7 @@ class MongoDBCollector(diamond.collector.Collector):
             self._publish_dict_with_prefix(data, base_prefix)
             db_name_filter = re.compile(self.config['databases'])
             ignored_collections = re.compile(self.config['ignore_collections'])
+            sample_threshold = self.MAX_CRC32 * self.config['collection_sample_rate']
             for db_name in conn.database_names():
                 if not db_name_filter.search(db_name):
                     continue
@@ -157,6 +169,10 @@ class MongoDBCollector(diamond.collector.Collector):
                 for collection_name in conn[db_name].collection_names():
                     if ignored_collections.search(collection_name):
                         continue
+                    if (self.config['collection_sample_rate'] < 1 and \
+                         (zlib.crc32(collection_name) & 0xffffffff) > sample_threshold):
+                            continue
+
                     collection_stats = conn[db_name].command('collstats',
                                                              collection_name)
                     if str_to_bool(self.config['translate_collections']):


### PR DESCRIPTION
We have many collections across our mongodb installation and don't want to be pushing data for every one of them to graphite. This option allows us to push only a subset of collections to graphite.
