### PR TITLE
Adding a dependency to zookeeper collector

### DIFF
--- a/src/collectors/zookeeper/zookeeper.py
+++ b/src/collectors/zookeeper/zookeeper.py
@@ -6,7 +6,8 @@ Collect zookeeper stats. ( Modified from memcached collector )
 #### Dependencies
 
  * subprocess
-
+ * Zookeeper 'mntr' command (zookeeper version => 3.4.0)
+ 
 #### Example Configuration
 
 ZookeeperCollector.conf


### PR DESCRIPTION
I've been struggling with this collector for quite some time, until I finally realized it's using the "mntr" zookeeper command, only available from zookeeper version 3.4.0
https://zookeeper.apache.org/doc/trunk/zookeeperAdmin.html#sc_zkCommands

I thought to put a small friendly reminder to the doc so the next person won't spend that much time.
