### PR TITLE
Emit a value of zero when an ELB metric has no activity

### DIFF
--- a/src/collectors/elb/test/testelb.py
+++ b/src/collectors/elb/test/testelb.py
@@ -92,7 +92,7 @@ class TestElbCollector(CollectorTestCase):
             publish_metric,
             {
                 'us-west-1a.elb1.HealthyHostCount': 1,
-                'us-west-1a.elb1.UnhealthyHostCount': 2,
+                'us-west-1a.elb1.UnHealthyHostCount': 2,
                 'us-west-1a.elb1.RequestCount': 3,
                 'us-west-1a.elb1.Latency': 4,
                 'us-west-1a.elb1.HTTPCode_ELB_4XX': 6,


### PR DESCRIPTION
Necessary because of the weird way that cloudwatch decides not to publish a metric if there is no activity.
