### PR TITLE
Add support for breaking queue collection by vhost.

### DIFF
--- a/src/collectors/rabbitmq/rabbitmq.py
+++ b/src/collectors/rabbitmq/rabbitmq.py
@@ -112,7 +112,7 @@ class RabbitMQCollector(diamond.collector.Collector):
                     for key in queue:
                         prefix = "queues"
                         if not legacy:
-                            prefix = "%s.%s" % (vhost, "queues")
+                            prefix = "vhosts.%s.%s" % (vhost, "queues")
 
                         name = '{0}.{1}'.format(prefix, queue['name'])
                         self._publish_metrics(name, [], key, queue)


### PR DESCRIPTION
The current RabbitMQ collector doesn't work well if running multiple virtual hosts with conflicting queue names.  This update shouldn't break people with a current deployment, but will allow a user to add config to split their metrics by vhost.

Basically, adding the following to the RabbitMQ collector configuration should cause collection of all queues split by vhost.

```
[vhosts]
* = *
```

More complex configurations should be possible as well.

```
[vhosts]
* = *
foo = baz bar
vhost2 = queue1 queue2 queue3
```

I've tested a fair amount on my systems attempting to ensure that the update would not break current deployments, so hopefully it should be safe. 
