### PR TITLE
Fix upstart path

### DIFF
--- a/debian/upstart/diamond.conf
+++ b/debian/upstart/diamond.conf
@@ -21,9 +21,10 @@ script
         DIAMOND_USER="diamond"
     fi
     PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+    DAEMON=`which diamond`
 
     # Launch Diamond if enabled in /etc/default
     if [ "x$ENABLE_DIAMOND" = "xyes" ]; then
-        exec start-stop-daemon --start --make-pidfile --chuid $DIAMOND_USER --pidfile $DIAMOND_PID --exec diamond -- --foreground --skip-change-user --skip-fork --skip-pidfile
+        exec start-stop-daemon --start --make-pidfile --chuid $DIAMOND_USER --pidfile $DIAMOND_PID --exec $DAEMON -- --foreground --skip-change-user --skip-fork --skip-pidfile
     fi
 end script


### PR DESCRIPTION
when doing a `pip install diamond` on ubuntu, for example, diamond is installed to /usr/local/bin
so the upstart script fails to start because it's looking for it in the wrong path, this will make it work for both.
