### PR TITLE
move script specification for rpm into setup.cfg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,6 @@ rpm: buildrpm
 
 buildrpm: sdist
 	./setup.py bdist_rpm \
-		--post-install=rpm/postinstall \
-		--pre-uninstall=rpm/preuninstall \
-		--install-script=rpm/install \
 		--release=`ls dist/*.noarch.rpm | wc -l`
 
 deb: builddeb

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [bdist_rpm]
 requires = python-configobj
 provides = diamond
+post-install = rpm/postinstall
+pre-install = rpm/preuninstall
+install-script = rpm/install


### PR DESCRIPTION
One problem with specifying it only in the Makefile, is that it becomes
cumbersome to invoke 'python setup.py bdist_rpm' since many options are needed.
This change simplifys building RPMs and allows easier building w/o using the
Makefile. Building RPMs via the Makefile remains intact.
