### PR TITLE
Fix float metric collection in userscripts and diskusage

### DIFF
--- a/src/collectors/diskusage/diskusage.py
+++ b/src/collectors/diskusage/diskusage.py
@@ -287,4 +287,4 @@ class DiskUsageCollector(diamond.collector.Collector):
                 for key in metrics:
                     metric_name = '.'.join([info['device'], key]).replace(
                         '/', '_')
-                    self.publish(metric_name, metrics[key])
+                    self.publish(metric_name, metrics[key], precision=4)

--- a/src/collectors/userscripts/userscripts.py
+++ b/src/collectors/userscripts/userscripts.py
@@ -91,4 +91,4 @@ class UserScriptsCollector(diamond.collector.Collector):
                 floatprecision = 0
                 if "." in value:
                     floatprecision = self.config['floatprecision']
-                self.publish(name, value, floatprecision)
+                self.publish(name, value, precision=floatprecision)


### PR DESCRIPTION
I tried adjusting unit tests as well, however comparing float values in tests seems completely broken now because of the way test.py accesses metrics submitted by collectors (`actual_value = calls[0][0][1]`). I am not that comfortable with the codebase to fix that properly.
