### PR TITLE
collectors/httpd: hack to add requests

### DIFF
--- a/src/collectors/httpd/httpd.py
+++ b/src/collectors/httpd/httpd.py
@@ -111,7 +111,11 @@ class HttpdCollector(diamond.collector.Collector):
                         if k == 'IdleWorkers':
                             continue
 
-                        if k == 'Scoreboard':
+                        if k == 'Total Accesses':
+                            self.publish_counter('req_handled', int(v))
+                            self._publish(nickname, k, v)
+
+                        elif k == 'Scoreboard':
                             for sb_kv in self._parseScoreboard(v):
                                 self._publish(nickname, sb_kv[0], sb_kv[1])
                         else:


### PR DESCRIPTION
The httpd collector records the requests handled as displayed from the apache status page.
This gives the number of requests handled on average since the server restarted.

It would be useful to have this use a counter to actually do this over the collector time period intstead / as well as the record the one reported by apache.

I've currently committed the fundamental sin of hacking the code in place as I needed the metrics urgently. This obviously isn't ideal and the code i've done isn't the best place to put this change.

So this issue is just me asking if others would find this useful, and if so get some feedback on the best place to put this change, and contribute this upstream.
