### PR TITLE
Fix diskspace collector's formatted disk names.

### DIFF
--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -107,6 +107,7 @@ class DiskSpaceCollector(diamond.collector.Collector):
             return labels
 
         for label in os.listdir(path):
+            label = label.replace('\\x2f', '/')
             device = os.path.realpath(path + '/' + label)
             labels[device] = label
 


### PR DESCRIPTION
Before: 
![screen shot 2014-04-06 at 2 28 07 pm](https://cloud.githubusercontent.com/assets/418213/2626500/d07d7b38-bdd3-11e3-967f-7fab7ae1ae08.png)

After: 
![screen shot 2014-04-06 at 2 37 46 pm](https://cloud.githubusercontent.com/assets/418213/2626501/d5760ce0-bdd3-11e3-8feb-1ffc4886fa79.png)

Cause:

```
chris@files63:~$ ls /dev/disk/by-label
\x2fhd\x2fd01ee  \x2fhd\x2fd01f1  \x2fhd\x2fd01f4  \x2fhd\x2fd01f8  \x2fhd\x2fd01fb  \x2fhd\x2fd02e0
\x2fhd\x2fd01ef  \x2fhd\x2fd01f2  \x2fhd\x2fd01f5  \x2fhd\x2fd01f9  \x2fhd\x2fd01fc
\x2fhd\x2fd01f0  \x2fhd\x2fd01f3  \x2fhd\x2fd01f6  \x2fhd\x2fd01fa  \x2fhd\x2fd01fd
```
