### PR TITLE
BUGFIX: they are functions, not data attributes

### DIFF
--- a/src/collectors/processresources/processresources.py
+++ b/src/collectors/processresources/processresources.py
@@ -154,10 +154,10 @@ class ProcessResourcesCollector(diamond.collector.Collector):
     def collect_process_info(self, process):
         try:
             pid = process.pid
-            name = process.name
-            cmdline = process.cmdline
+            name = process.name()
+            cmdline = process.cmdline()
             try:
-                exe = process.exe
+                exe = process.exe()
             except psutil.AccessDenied:
                 exe = ""
             for pg_name, cfg in self.processes.items():


### PR DESCRIPTION
```
In [1]: import psutil

In [2]: p = psutil.Process()

In [3]: p.name?
Type:       instancemethod
String Form:<bound method Process.name of <psutil.Process(pid=16818, name='ipython') at 25689296>>
File:       /home/hvn/python2/local/lib/python2.7/site-packages/psutil/__init__.py
Definition: p.name(self)
Docstring:  The process name. The return value is cached after first call.

In [4]: p.cmdline?
Type:       instancemethod
String Form:<bound method Process.cmdline of <psutil.Process(pid=16818, name='ipython') at 25689296>>
File:       /home/hvn/python2/local/lib/python2.7/site-packages/psutil/__init__.py
Definition: p.cmdline(self)
Docstring:  The command line this process has been called with.

In [5]: p.exe?
Type:       instancemethod
String Form:<bound method Process.exe of <psutil.Process(pid=16818, name='ipython') at 25689296>>
File:       /home/hvn/python2/local/lib/python2.7/site-packages/psutil/__init__.py
Definition: p.exe(self)
Docstring:
The process executable as an absolute path.
May also be an empty string.
The return value is cached after first call.

In [6]: p.pid
Out[6]: 16818


```
