### PR TITLE
Updated to remove a division by zero

### DIFF
--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -258,9 +258,10 @@ class DiskSpaceCollector(diamond.collector.Collector):
                     self.publish_gauge(metric_name, metric_value, 2)
 
             if os.name != 'nt':
-                self.publish_gauge(
-                    '%s.inodes_percentfree' % name,
-                    float(inodes_free) / float(inodes_total) * 100)
+                if float(inodes_total) > 0:
+                    self.publish_gauge(
+                        '%s.inodes_percentfree' % name,
+                        float(inodes_free) / float(inodes_total) * 100)
                 self.publish_gauge('%s.inodes_used' % name,
                                    inodes_total - inodes_free)
                 self.publish_gauge('%s.inodes_free' % name, inodes_free)


### PR DESCRIPTION
Using btrfs as fs lead to a report of 0 inodes, creating a division by zero:

[2014-04-18 20:58:26,570] [Thread-11] Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/diamond/collector.py", line 423, in _run
    self.collect()
  File "/usr/share/diamond/collectors/diskspace/diskspace.py", line 263, in collect
    float(inodes_free) / float(inodes_total) \* 100)
ZeroDivisionError: float division by zero

Test : 

> > > data = os.statvfs('/opt/data')
> > > data
> > > posix.statvfs_result(f_bsize=4096, f_frsize=4096, f_blocks=44564480, f_bfree=26219965, f_bavail=25761775, f_files=0, f_ffree=0, f_favail=0, f_flag=4096, f_namemax=255)

Will look into it to add btrfs support...
