### PR TITLE
late check pysnmp module to not log error on startup

### DIFF
--- a/src/collectors/snmp/snmp.py
+++ b/src/collectors/snmp/snmp.py
@@ -44,13 +44,6 @@ class SNMPCollector(diamond.collector.Collector):
         # Initialize base Class
         diamond.collector.Collector.__init__(self, config, handlers)
 
-        # Initialize SNMP Command Generator
-        if cmdgen:
-            self.snmpCmdGen = cmdgen.CommandGenerator()
-        else:
-            self.log.error(
-                'pysnmp.entity.rfc3413.oneliner.cmdgen failed to load')
-
     def get_default_config_help(self):
         config_help = super(SNMPCollector, self).get_default_config_help()
         config_help.update({
@@ -74,6 +67,15 @@ class SNMPCollector(diamond.collector.Collector):
         Override SNMPCollector.get_schedule
         """
         schedule = {}
+
+        if not cmdgen:
+            self.log.error(
+                'pysnmp.entity.rfc3413.oneliner.cmdgen failed to load')
+            return
+
+        # Initialize SNMP Command Generator
+        self.snmpCmdGen = cmdgen.CommandGenerator()
+
         if 'devices' in self.config:
             for device in self.config['devices']:
                 # Get Device Config


### PR DESCRIPTION
This help not show bellow error on startup:

```
Apr 26 03:22:26 backup diamond[22844] ERROR diamond snmp.__init__:52 pysnmp.entity.rfc3413.oneliner.cmdgen failed to load
Apr 26 03:22:26 backup diamond[22844] message repeated 2 times: [ ERROR diamond snmp.__init__:52 pysnmp.entity.rfc3413.oneliner.cmdgen failed to load]
```

I'm not a snmp collector user, so I'm not testing whether those collectors still work well after my change.
