### PR TITLE
BUGFIX: They might be functions

### DIFF
--- a/src/collectors/processresources/processresources.py
+++ b/src/collectors/processresources/processresources.py
@@ -80,6 +80,13 @@ def process_info(process, info_keys):
                 results.update({"%s.%s" % (key, subkey): subvalue})
     return results
 
+	
+def get_value(process, name):
+	result = getattr(process, name)
+	try:
+		return result()
+	except TypeError:
+		return result
 
 class ProcessResourcesCollector(diamond.collector.Collector):
     def __init__(self, *args, **kwargs):
@@ -150,14 +157,14 @@ class ProcessResourcesCollector(diamond.collector.Collector):
                 self.processes_info[pg_name][key] += value
             else:
                 self.processes_info[pg_name][key] = value
-
+			
     def collect_process_info(self, process):
         try:
-            pid = process.pid
-            name = process.name()
-            cmdline = process.cmdline()
+            pid = get_value(process, 'pid')
+            name = get_value(process, 'name')
+            cmdline = get_value(process, 'cmdline')
             try:
-                exe = process.exe()
+                exe = get_value(process, 'exe')
             except psutil.AccessDenied:
                 exe = ""
             for pg_name, cfg in self.processes.items():


### PR DESCRIPTION
Commit 585a2eb0c488dec1a146e665963a617eb9bfc754 changed the code assuming name, cmdline and exe are functions and not attributes of process. On my system (Ubuntu 14.04 and Python 2.7.6) they are attributes. If that is varying then I think it would be good to allow both.
