### PR TITLE
Vagrantfile: Add centos6-devel vagrantbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,4 +41,15 @@ Vagrant.configure("2") do |config|
     c.vm.provision "shell", inline: "cd /tmp/Diamond && make deb"
     c.vm.provision "shell", inline: "mkdir -p /vagrant/dist/deb && (cp -f /tmp/Diamond/build/*.deb /vagrant/dist/deb/ || grep -v 'cannot stat')"
   end
+
+  config.vm.define "centos6-devel" do |c|
+    c.vm.hostname = "centos-devel"
+    c.vm.box = "opscode_centos-6.5"
+    c.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box"
+
+    c.vm.provision "shell", inline: "sudo rpm -ivh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm"
+    c.vm.provision "shell", inline: "sudo yum install -y git rpm-build python-configobj python-test python-mock tree vim-enhanced"
+    c.vm.provision "shell", inline: "sudo cp /vagrant/vimrc /home/vagrant/.vimrc"
+  end
+
 end

--- a/vimrc
+++ b/vimrc
@@ -1,0 +1,4 @@
+colorscheme desert
+set tabstop=4
+set shiftwidth=4
+set expandtab


### PR DESCRIPTION
Centos6-devel vagrantbox automatically installs python libraries for unit testing and a basic vimrc for the vagrant user.
