### PR TITLE
memory_docker: remove py27ism

### DIFF
--- a/src/collectors/memory_docker/memory_docker.py
+++ b/src/collectors/memory_docker/memory_docker.py
@@ -23,9 +23,9 @@ class MemoryDockerCollector(MemoryCgroupCollector):
             self.log.error('Unable to import docker')
             return
 
-        self.containers = {c['Id']: c['Names'][0][1:]
+        self.containers = dict((c['Id'], c['Names'][0][1:])
                            for c in docker.Client().containers(all=True)
-                           if c['Names'] is not None}
+                           if c['Names'] is not None)
         return super(MemoryDockerCollector, self).collect()
 
     def publish(self, metric_name, value, metric_type):


### PR DESCRIPTION
Won't compile under python .26 without this. Fixes #590
