### PR TITLE
ElbCollector should not complain about invalid interval if it's disabled

### DIFF
--- a/src/collectors/elb/elb.py
+++ b/src/collectors/elb/elb.py
@@ -109,7 +109,8 @@ class ElbCollector(diamond.collector.Collector):
                 # the creds from the instance metatdata.
                 self.auth_kwargs = {}
 
-        validate_interval()
+        if config['enabled']:
+            validate_interval()
         setup_creds()
         self.max_delayed = self.config.as_int('max_delayed')
         self.history = dict()


### PR DESCRIPTION
We set interval=10 in the collectors.default section of our diamond.conf.  We don't use ElbCollector, but it throws a nasty error anyway because it doesn't like an interval of 10 seconds.
