### PR TITLE
put more infromation in exception to help indicating problem source

### DIFF
--- a/src/diamond/metric.py
+++ b/src/diamond/metric.py
@@ -25,7 +25,10 @@ class Metric(object):
 
         # Validate the path, value and metric_type submitted
         if (None in [path, value] or metric_type not in self._METRIC_TYPES):
-            raise DiamondException("Invalid parameter.")
+            raise DiamondException(("Invalid parameter when creating new "
+                                    "Metric with path: %r value: %r "
+                                    "metric_type: %r")
+                                   % (path, value, metric_type))
 
         # If no timestamp was passed in, set it to the current time
         if timestamp is None:
@@ -36,7 +39,9 @@ class Metric(object):
                 try:
                     timestamp = int(timestamp)
                 except ValueError, e:
-                    raise DiamondException("Invalid parameter: %s" % e)
+                    raise DiamondException(("Invalid timestamp when "
+                                            "creating new Metric %r: %s")
+                                           % (path, e))
 
         # The value needs to be a float or an int.  If it is, great.  If not,
         # try to cast it to one of those.
@@ -47,7 +52,8 @@ class Metric(object):
                 else:
                     value = float(value)
             except ValueError, e:
-                raise DiamondException("Invalid parameter: %s" % e)
+                raise DiamondException(("Invalid value when creating new "
+                                        "Metric %r: %s") % (path, e))
 
         self.path = path
         self.value = value


### PR DESCRIPTION
if user use sentry to log exception out, he only need to look into sentry
to know what went wrong without checking log file

I passed a bad value to ntpdcollector to test this, it now displays:

```
  File "/home/hvn/python2/local/lib/python2.7/site-packages/diamond/collector.py", line 429, in _run
    self.collect()
  File "/home/hvn/Github/Diamond/src/collectors/ntpd/ntpd.py", line 113, in collect
    self.publish(stat, val)
  File "/home/hvn/python2/local/lib/python2.7/site-packages/diamond/collector.py", line 343, in publish
    metric_type=metric_type, ttl=ttl)
  File "/home/hvn/python2/local/lib/python2.7/site-packages/diamond/metric.py", line 56, in __init__
    "Metric %r: %s") % (path, e))
DiamondException: Invalid value when creating new Metric 'servers.hvnwork.ntpd.when': invalid literal for float(): 1y
```
