### PR TITLE
it is trivial if a process stop when processresource is collecting

### DIFF
--- a/src/collectors/processresources/processresources.py
+++ b/src/collectors/processresources/processresources.py
@@ -175,7 +175,7 @@ class ProcessResourcesCollector(diamond.collector.Collector):
                         pi.update({'workers_count': 1})
                     self.save_process_info(pg_name, pi)
         except psutil.NoSuchProcess, e:
-            self.log.warning("Process exited while trying to get info: %s", e)
+            self.log.info("Process exited while trying to get info: %s", e)
 
     def collect(self):
         """


### PR DESCRIPTION
Therefore, logs it at INFO level to not flooding logging system which
often set to WARNING level in production

Context: we are using graylog2 for centralize logging, we set our log level at warning. This log showed up so many time, but it does not indicate any real warning problem. So I want to reduce its level, this may be  controversial.
