### PR TITLE
Fix publish call. 'new_size' is argument to publish(), not format string

### DIFF
--- a/src/collectors/s3/s3.py
+++ b/src/collectors/s3/s3.py
@@ -71,5 +71,5 @@ class S3BucketCollector(diamond.collector.Collector):
                         oldUnit='byte',
                         newUnit=byte_unit
                     )
-                    self.publish("%s.size.%s" % (bucket_name, byte_unit,
-                                                 new_size))
+                    self.publish("%s.size.%s" % (bucket_name, byte_unit),
+                                 new_size))


### PR DESCRIPTION
`new_size`parameter should be an argument to `publish()` call, not for the format string. Otherwise we'll get the following error:

```
[2014-05-20 06:47:28,936] [Thread-1] Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/diamond/collector.py", line 423, in _run
    self.collect()
  File "/usr/share/diamond/collectors/s3/s3.py", line 75, in collect
    new_size))
TypeError: not all arguments converted during string formatting
```
