### PR TITLE
add btrfs to supported fs type

### DIFF
--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -55,7 +55,7 @@ class DiskSpaceCollector(diamond.collector.Collector):
             'path': 'diskspace',
             # filesystems to examine
             'filesystems': 'ext2, ext3, ext4, xfs, glusterfs, nfs, ntfs, hfs,'
-            + ' fat32, fat16',
+            + ' fat32, fat16, btrfs',
 
             # exclude_filters
             #   A list of regex patterns


### PR DESCRIPTION
Now the collector can hanfle 0 inodes values without doing a division by zero, btrfs can be added to the supported filesystems to check.
