### PR TITLE
Continue on most exceptions to prevent cascading failure during importation of collectors.

### DIFF
--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -188,7 +188,14 @@ class Server(object):
                 try:
                     # Import the module
                     mod = __import__(modname, globals(), locals(), ['*'])
-                except (ImportError, SyntaxError):
+                except (KeyboardInterrupt, SystemExit) as err:
+                    self.log.error(
+                        "System or keyboard interrupt while loading module %s"
+                        % modname)
+                    if isinstance(err, SystemExit):
+                        sys.exit(err.code)
+                    raise KeyboardInterrupt
+                except:
                     # Log error
                     self.log.error("Failed to import module: %s. %s", modname,
                                    traceback.format_exc())


### PR DESCRIPTION
- Exceptions from the loading or initialization of a module (collector)
  should not be allowed to bubble up and cause diamond to fail.
- A failure here should be caught and reported. It should not cause
  the entire application to fail.
