### PR TITLE
is memcached uptime really supposed to be a counter?

### DIFF
--- a/src/collectors/memcached/memcached.py
+++ b/src/collectors/memcached/memcached.py
@@ -42,6 +42,7 @@ class MemcachedCollector(diamond.collector.Collector):
         'hash_power_level',
         'hash_bytes',
         'hash_is_expanding',
+        'uptime'
     ]
 
     def get_default_config_help(self):


### PR DESCRIPTION
added uptime to the gauges list for memcached - does a rate (and so always poller interval...) make any sense for this value?
