### PR TITLE
fix a bug of extended postgres collector

### DIFF
--- a/src/collectors/postgres/postgres.py
+++ b/src/collectors/postgres/postgres.py
@@ -520,11 +520,11 @@ metrics_registry = {
 }
 
 registry = {
-    'basic': (
+    'basic': [
         'DatabaseStats',
         'DatabaseConnectionCount',
-    ),
-    'extended': (
+    ],
+    'extended': [
         'DatabaseStats',
         'DatabaseConnectionCount',
         'UserTableStats',
@@ -541,5 +541,5 @@ registry = {
         'UserConnectionCount',
         'TableScanStats',
         'TupleAccessStats',
-    ),
+    ],
 }


### PR DESCRIPTION
registry must respond to append method because it is called in this line
https://github.com/BrightcoveOS/Diamond/blob/77760a2676f3cada3cdc3cc5628a251985616d7f/src/collectors/postgres/postgres.py#L90
