### PR TITLE
Update diamond

### DIFF
--- a/bin/init.d/diamond
+++ b/bin/init.d/diamond
@@ -33,6 +33,8 @@ LOCKFILE=/var/lock/subsys/diamond
 start() {
   if [ -d "${LOCKDIR}" -a -w "${LOCKDIR}" ]
   then
+    local pid
+    __pids_var_run $NAME || rm -f "${LOCKFILE}"
     if ( set -o noclobber; echo "$$" > "${LOCKFILE}") 2> /dev/null;
     then
       true


### PR DESCRIPTION
If diamond dies for any reason it leaves the lockfile /var/local/subsys/diamond and the pidfile /var/run/diamond.pid sitting on the disc. This prevents future attempts to 'service diamond start'. This change checks that diamond is still alive before looking at the lockfile. If it is not alive, the lockfile is zapped and diamond can then be started. Tested on RHEL5 as 

/etc/init.d/diamond [start|stop|status]
service diamond [start|stop|status]
