### PR TITLE
Patch beanstalkd collector

### DIFF
--- a/src/collectors/beanstalkd/beanstalkd.py
+++ b/src/collectors/beanstalkd/beanstalkd.py
@@ -22,6 +22,7 @@ except ImportError:
 
 
 class BeanstalkdCollector(diamond.collector.Collector):
+    SKIP_LIST = ['version', 'id', 'hostname']
     COUNTERS_REGEX = re.compile(
         r'^(cmd-.*|job-timeouts|total-jobs|total-connections)$')
 
@@ -72,7 +73,7 @@ class BeanstalkdCollector(diamond.collector.Collector):
         info = self._get_stats()
 
         for stat, value in info['instance'].items():
-            if stat != 'version':
+            if stat not in self.SKIP_LIST:
                 self.publish(stat, value,
                              metric_type=self.get_metric_type(stat))
 


### PR DESCRIPTION
'version', 'id', and 'hostname' are not statistics and can be ignored. Trying to parse these results in the following exception:

```
File "/usr/lib/pymodules/python2.7/diamond/collector.py", line 412, in _run
  self.collect()
File "/usr/share/diamond/collectors/beanstalkd/beanstalkd.py", line 77, in collect
  metric_type=self.get_metric_type(stat))
File "/usr/lib/pymodules/python2.7/diamond/collector.py", line 330, in publish
  metric_type=metric_type)
File "/usr/lib/pymodules/python2.7/diamond/metric.py", line 52, in __init__
  raise DiamondException("Invalid parameter: %s" % e)
DiamondException: Invalid parameter: invalid literal for float(): 5ea7e12f9fec41d9
```

See the beanstalkd protocol for a full list of outputs, and their description:
https://github.com/kr/beanstalkd/blob/master/doc/protocol.txt

```
- "version" is the version string of the server.
- "id" is a random id string for this server process, generated when each beanstalkd process starts.
- "hostname" the hostname of the machine as determined by uname.
```
