### PR TITLE
Add a new hostname_method=shell.

### DIFF
--- a/conf/diamond.conf.example
+++ b/conf/diamond.conf.example
@@ -154,6 +154,9 @@ batch = 100
 # hostname          = `hostname`
 # hostname_rev      = `hostname` in reverse (com.example.www)
 
+# shell             = Run the string set in hostname as a shell command and use its
+#                     output(with spaces trimmed off from both ends) as the hostname.
+
 # hostname_method = smart
 
 # Path Prefix and Suffix

--- a/src/diamond/test/testcollector.py
+++ b/src/diamond/test/testcollector.py
@@ -20,3 +20,16 @@ class BaseCollectorTest(unittest.TestCase):
         }
         c = Collector(config, [])
         self.assertEquals('custom.localhost', c.get_hostname())
+
+    def test_SetHostnameViaShellCmd(self):
+        config = configobj.ConfigObj()
+        config['server'] = {}
+        config['server']['collectors_config_path'] = ''
+        config['collectors'] = {}
+        config['collectors']['default'] = {
+            'hostname': 'echo custom.localhost',
+            'hostname_method': 'shell',
+        }
+        c = Collector(config, [])
+        self.assertEquals('custom.localhost', c.get_hostname())
+


### PR DESCRIPTION
The `shell` hostname method will run the string set in the `hostname`
key through the default shell and use its stdout as the hostname.
