### PR TITLE
Fixes issue with collect_snmp stepping over the same devices multiple times

### DIFF
--- a/src/collectors/snmpraw/snmpraw.py
+++ b/src/collectors/snmpraw/snmpraw.py
@@ -161,11 +161,8 @@ class SNMPRawCollector(parent_SNMPCollector):
         self.log.debug(
             'Collecting raw SNMP statistics from device \'{0}\''.format(device))
 
-        for device in self.config['devices']:
-            dev_config = self.config['devices'][device]
-            if not 'oids' in dev_config:
-                continue
-
+        dev_config = self.config['devices'][device]
+        if 'oids' in dev_config:
             for oid, metricName in dev_config['oids'].items():
 
                 if (device, oid) in self.skip_list:


### PR DESCRIPTION
SNMPCollector schedules each device and it's related oid's. Then when SNMPRawCollector's function collect_snmp is called, it was stepping over all the devices in the config again when it should only retrieve the oid's for the current device. 
