### PR TITLE
Make sure to kill old diamond process even if killproc fails.

### DIFF
--- a/bin/init.d/diamond
+++ b/bin/init.d/diamond
@@ -63,6 +63,10 @@ stop() {
   echo -n $"Stopping $NAME: "
   killproc -p $PIDFILE $NAME
   retval=$?
+  if [ $retval -ne 0 ];
+  then
+    killall -q diamond
+  fi
   if [ -e "${LOCKFILE}" ]
   then
     rm -f "${LOCKFILE}"


### PR DESCRIPTION
Otherwise we end up with multiple diamond processes reporting.
