### PR TITLE
fix(feat): better exception handling in uptime collector to pass tests

### DIFF
--- a/src/collectors/uptime/uptime.py
+++ b/src/collectors/uptime/uptime.py
@@ -7,16 +7,6 @@ procpath = '/proc/uptime'
 metric_name = 'minutes'
 
 
-def read():
-    try:
-        fd = open(procpath)
-        uptime = fd.readline()
-    finally:
-        fd.close()
-    v = float(uptime.split()[0].strip())
-    return convertor.time.convert(v, 's', 'm')
-
-
 class UptimeCollector(Collector):
     def get_default_config(self):
         config = super(UptimeCollector, self).get_default_config()
@@ -27,12 +17,20 @@ class UptimeCollector(Collector):
 
     def collect(self):
         if not os.path.exists(procpath):
-            self.log.error('path: {0} not found'.format(procpath))
+            self.log.error('Input path %s does not exist' % procpath)
             return {}
 
-        try:
-            v = read()
-        except Exception as e:
-            self.log.exception(e)
+        v = self.read()
+        if not v is None:
+            self.publish(metric_name, v)
 
-        self.publish(metric_name, v)
+    def read(self):
+        try:
+            fd = open(procpath)
+            uptime = fd.readline()
+            fd.close()
+            v = float(uptime.split()[0].strip())
+            return convertor.time.convert(v, 's', 'm')
+        except Exception, e:
+            self.log.error('Unable to read uptime from %s: %s' % (procpath, e))
+            return None


### PR DESCRIPTION
Unittest "TestUptimeCollector.test_malformed_input" triggered a case of bad exception handling in the uptime collector. Made read() a class method to have access to self.log and I stopped passing the exception object to log method. Not completely sure why we got huge exceptions, but with this fix its stopped.

This has been breaking Travis since some time. Examples for bad runs:
- python 2.6 https://travis-ci.org/python-diamond/Diamond/jobs/31677475
- python 2.7 https://travis-ci.org/python-diamond/Diamond/jobs/31677476
