### PR TITLE
fix(feat): bug fixed to allow pass of elasticsearch unittest

### DIFF
--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -231,7 +231,8 @@ class ElasticSearchCollector(diamond.collector.Collector):
                       'non_heap_committed'):
                 metrics['jvm.mem.%s' % k] = mem['%s_in_bytes' % k]
 
-            metrics['jvm.mem.heap_used_percent'] = mem['heap_used_percent']
+            if 'heap_used_percent' in mem:
+                metrics['jvm.mem.heap_used_percent'] = mem['heap_used_percent']
 
             for pool, d in mem['pools'].iteritems():
                 pool = pool.replace(' ', '_')


### PR DESCRIPTION
Recent codechange in elasticsearch collector broke the unittest.

New code expected the ES statsd data to contain the 'jvm.mem.heap_used_percent' field.
The unittest works with fixture data from a ES version before the 'heap_used_percent' field was implemented.

Causing KeyError exceptions:

```
======================================================================
ERROR: test_should_work_with_real_0_90_data (testelasticsearch.TestElasticSearchCollector)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/work/app/src/collectors/elasticsearch/test/testelasticsearch.py", line 157, in test_should_work_with_real_0_90_data
    self.collector.collect()
  File "/work/app/src/collectors/elasticsearch/elasticsearch.py", line 234, in collect
    metrics['jvm.mem.heap_used_percent'] = mem['heap_used_percent']
KeyError: 'heap_used_percent'

======================================================================
ERROR: test_should_work_with_real_data (testelasticsearch.TestElasticSearchCollector)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/work/app/src/collectors/elasticsearch/test/testelasticsearch.py", line 36, in test_should_work_with_real_data
    self.collector.collect()
  File "/work/app/src/collectors/elasticsearch/elasticsearch.py", line 234, in collect
    metrics['jvm.mem.heap_used_percent'] = mem['heap_used_percent']
KeyError: 'heap_used_percent'

======================================================================
ERROR: test_should_work_with_real_data_logstash_mode (testelasticsearch.TestElasticSearchCollector)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/mock.py", line 1201, in patched
    return func(*args, **keywargs)
  File "/work/app/src/collectors/elasticsearch/test/testelasticsearch.py", line 90, in test_should_work_with_real_data_logstash_mode
    self.collector.collect()
  File "/work/app/src/collectors/elasticsearch/elasticsearch.py", line 234, in collect
    metrics['jvm.mem.heap_used_percent'] = mem['heap_used_percent']
KeyError: 'heap_used_percent'
```
