### PR TITLE
Auto detect ipv6 by default in graphite handler

### DIFF
--- a/src/diamond/handler/graphite.py
+++ b/src/diamond/handler/graphite.py
@@ -92,8 +92,8 @@ class GraphiteHandler(Handler):
             'trim_backlog_multiplier': 4,
             'keepalive': 0,
             'keepaliveinterval': 10,
-            'flow_info': '0',
-            'scope_id': '0',
+            'flow_info': 0,
+            'scope_id': 0,
         })
 
         return config


### PR DESCRIPTION
I think diamond should auto detect if it should use ipv4 or ipv6 by default when talking to graphite, but still allow one to explicitly specify one of them in the config.
