### PR TITLE
fix(feat): jcollectd collector with better metric name cleanup

### DIFF
--- a/src/collectors/jcollectd/jcollectd.py
+++ b/src/collectors/jcollectd/jcollectd.py
@@ -184,7 +184,7 @@ class ListenerThread(threading.Thread):
         parts.append(item.typeinstance)
 
         # construct full path, from safe parts
-        name = '.'.join([re.sub('[\. /]', '_', part) for part in parts])
+        name = '.'.join([sanitize_word(part) for part in parts])
 
         if item[0][0] == 0:
             is_counter = True
@@ -193,6 +193,15 @@ class ListenerThread(threading.Thread):
         dp = Datapoint(item.host, item.time, name, item[0][1], is_counter)
 
         return dp
+
+
+def sanitize_word(s):
+    """Remove non-alphanumerical characters from metric word.
+    And trim excessive underscores.
+    """
+    s = re.sub('[^\w-]+', '_', s)
+    s = re.sub('__+', '_', s)
+    return s.strip('_')
 
 
 class Datapoint(object):

--- a/src/collectors/jcollectd/test/testjcollectd.py
+++ b/src/collectors/jcollectd/test/testjcollectd.py
@@ -10,7 +10,7 @@ from mock import Mock
 from mock import patch
 
 from diamond.collector import Collector
-from jcollectd import JCollectdCollector
+from jcollectd import JCollectdCollector, sanitize_word
 
 
 ###############################################################################
@@ -23,6 +23,14 @@ class TestJCollectdCollector(CollectorTestCase):
 
     def test_import(self):
         self.assertTrue(JCollectdCollector)
+
+    def test_sanitize(self):
+        self.assertEqual(sanitize_word('bla'), 'bla')
+        self.assertEqual(sanitize_word('bla:'), 'bla')
+        self.assertEqual(sanitize_word('foo:bar'), 'foo_bar')
+        self.assertEqual(sanitize_word('foo:!bar'), 'foo_bar')
+        self.assertEqual(sanitize_word('"ou812"'), 'ou812')
+        self.assertEqual(sanitize_word('Aap! N@@t mi_es'), 'Aap_N_t_mi_es')
 
 ###############################################################################
 if __name__ == "__main__":


### PR DESCRIPTION
Tomcat7 puts quotes in its GlobalThreadPool mbean names. Graphite accepts those characters, but makes it impossible to search. So I changed the cleanup bit.
