### PR TITLE
network: let 'greed' match 0 character

### DIFF
--- a/src/collectors/network/network.py
+++ b/src/collectors/network/network.py
@@ -62,7 +62,7 @@ class NetworkCollector(diamond.collector.Collector):
             # Build Regular Expression
             greed = ''
             if self.config['greedy'].lower() == 'true':
-                greed = '\S+'
+                greed = '\S*'
 
             exp = ('^(?:\s*)((?:%s)%s):(?:\s*)'
                    + '(?P<rx_bytes>\d+)(?:\s*)'


### PR DESCRIPTION
This is useful to monitor the 'lo' interface for example.
