### PR TITLE
cleanup quotes in bean names... looking at you Kafka

### DIFF
--- a/src/collectors/jolokia/jolokia.py
+++ b/src/collectors/jolokia/jolokia.py
@@ -132,6 +132,7 @@ class JolokiaCollector(diamond.collector.Collector):
     def clean_up(self, text):
         text = re.sub('[:,]', '.', text)
         text = re.sub('[=\s]', '_', text)
+        text = re.sub('["\']', '', text)
         return text
 
     def collect_bean(self, prefix, obj):


### PR DESCRIPTION
Kafka's JMX beans have quotes all over the place... probably because Scala
