### PR TITLE
Fix: RedisCollector does not support @ in password

### DIFF
--- a/src/collectors/redisstat/redisstat.py
+++ b/src/collectors/redisstat/redisstat.py
@@ -103,7 +103,7 @@ class RedisCollector(diamond.collector.Collector):
         for instance in instance_list:
 
             if '@' in instance:
-                (nickname, hostport) = instance.split('@', 2)
+                (nickname, hostport) = instance.split('@', 1)
             else:
                 nickname = None
                 hostport = instance

--- a/src/collectors/redisstat/test/testredisstat.py
+++ b/src/collectors/redisstat/test/testredisstat.py
@@ -274,6 +274,7 @@ class TestRedisCollector(CollectorTestCase):
                 'nick1@host1:1111',
                 'nick2@:2222',
                 'nick3@host3',
+                'nick4@host4:3333/@password',
                 'bla'
             ]
         }
@@ -293,6 +294,10 @@ class TestRedisCollector(CollectorTestCase):
             call('nick3.process.connections_received', 200, precision=0,
                  metric_type='GAUGE'),
             call('nick3.process.commands_processed', 100, precision=0,
+                 metric_type='GAUGE'),
+            call('nick4.process.connections_received', 200, precision=0,
+                 metric_type='GAUGE'),
+            call('nick4.process.commands_processed', 100, precision=0,
                  metric_type='GAUGE'),
             call('6379.process.connections_received', 200, precision=0,
                  metric_type='GAUGE'),


### PR DESCRIPTION
In multi-instance mode, RedisCollector does not support the @ symbol appearing in a password:

```
2014-09-05 04:49:59,980] [MainThread] Failed to initialize Collector: RedisCollector. Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/diamond/server.py", line 244, in init_collector
    collector = cls(self.config, self.handlers)
  File "/usr/share/diamond/collectors/redisstat/redisstat.py", line 106, in __init__
    (nickname, hostport) = instance.split('@', 2)
ValueError: too many values to unpack
```
