### PR TITLE
Fix syntax error in icinga_stats collector

### DIFF
--- a/src/collectors/icinga_stats/icinga_stats.py
+++ b/src/collectors/icinga_stats/icinga_stats.py
@@ -261,10 +261,10 @@ class IcingaStatsCollector(diamond.collector.Collector):
          * parallel_host_check_stats
         """
         stats = {}
-        app_keys = {
+        app_keys = [
             "serial_host_check_stats",
             "parallel_host_check_stats",
-            }
+            ]
         for app_key in app_keys:
             if app_key not in app_stats.keys():
                 continue


### PR DESCRIPTION
Commit fixes syntax error in icinga_stats collector - replace {} with [].

Fix https://github.com/BrightcoveOS/Diamond/issues/728.
