### PR TITLE
DRBD collector - Fix up regex for nonexistent replication mode.

### DIFF
--- a/src/collectors/drbd/drbd.py
+++ b/src/collectors/drbd/drbd.py
@@ -61,7 +61,7 @@ class DRBDCollector(diamond.collector.Collector):
                 if re.search('version', line) is None:
                     if re.search(r' \d: cs', line):
                         matches = re.match(r' (\d): (cs:\w+) (ro:\w+/\w+) '
-                                           '(ds:\w+/\w+) (\w{1}) .*', line)
+                                           '(ds:\w+/\w+) (.) .*', line)
                         current_resource = matches.group(1)
                         results[current_resource] = dict()
                     elif re.search(r'\sns:', line):

--- a/src/collectors/drbd/test/fixtures/proc_drbd_1
+++ b/src/collectors/drbd/test/fixtures/proc_drbd_1
@@ -1,0 +1,4 @@
+version: 8.3.7 (api:88/proto:86-91)
+srcversion: EE47D8BF18AC166BE219757
+ 0: cs:Connected ro:Primary/Secondary ds:UpToDate/UpToDate C r----
+    ns:989271740 nr:0 dw:989265708 dr:22157009 al:1992324 bm:58 lo:1 pe:0 ua:0 ap:1 ep:1 wo:b oos:0

--- a/src/collectors/drbd/test/fixtures/proc_drbd_2
+++ b/src/collectors/drbd/test/fixtures/proc_drbd_2
@@ -1,0 +1,4 @@
+version: 8.3.7 (api:88/proto:86-91)
+srcversion: EE47D8BF18AC166BE219757
+ 0: cs:StandAlone ro:Primary/Unknown ds:UpToDate/Outdated   r----
+    ns:0 nr:0 dw:94696040 dr:41089 al:76 bm:0 lo:0 pe:0 ua:0 ap:0 ep:1 wo:b oos:304148


### PR DESCRIPTION
The previous regex (\w{1}) was looking for a single alphanumeric character, however in some states, the replication mode this regex was collecting is nonexistent / an empty space.

Example of a good replication mode that exists (C):

<pre>
 0: cs:Connected ro:Secondary/Primary ds:UpToDate/UpToDate C r----
<pre>

Example of a nonexistent replication mode (does not exist - not the missing replication state flag A, B, or C [1]):
<pre>
 0: cs:StandAlone ro:Primary/Unknown ds:UpToDate/Outdated   r----
</pre>


Attempting to regex on the nonexistent replication mode was throwing an exception since the replication mode did not exist:

<pre>
[2014-10-03 14:08:19,949] [Thread-1] Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.6/diamond/collector.py", line 412, in _run
    self.collect()
  File "/usr/share/diamond/collectors/drbd/drbd.py", line 63, in collect
    current_resource = matches.group(1)
AttributeError: 'NoneType' object has no attribute 'group'
</pre>


References:
[1] http://www.drbd.org/users-guide/s-replication-protocols.html
