### PR TITLE
Handle DNS resolution error in graphite handler

### DIFF
--- a/src/diamond/handler/graphite.py
+++ b/src/diamond/handler/graphite.py
@@ -185,7 +185,13 @@ class GraphiteHandler(Handler):
                                  self.flow_info, self.scope_id)
         else:
             connection_struct = (self.host, self.port)
-            addrinfo = socket.getaddrinfo(self.host, self.port, 0, stream)
+            try:
+                addrinfo = socket.getaddrinfo(self.host, self.port, 0, stream)
+            except socket.gaierror, ex:
+                self.log.error("GraphiteHandler: Error looking up graphite host"
+                               " '%s' - %s",
+                               self.host, ex)
+                return
             if (len(addrinfo) > 0):
                 family = addrinfo[0][0]
                 if (family == socket.AF_INET6):


### PR DESCRIPTION
Handle DNS resolution error when using graphite handler in TCP mode. Resolves #745 
