### PR TITLE
Some modules use the warnings API.

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -165,6 +165,7 @@ class Collector(object):
         Create a new instance of the Collector class
         """
         # Initialize Logger
+        logging.captureWarnings(True)
         self.log = logging.getLogger('diamond')
         # Initialize Members
         self.name = self.__class__.__name__


### PR DESCRIPTION
I struggle with pymongo, this module use the warnings API:
https://docs.python.org/2.7/library/warnings.html?highlight=warnings#module-warnings

The multi threaded Diamond architecture doesn't allow to use STDOUT or STDERR.

The logging API can capture warnings messages: 
https://docs.python.org/2.7/library/logging.html#logging.captureWarnings 