### PR TITLE
Fix rpm make target to explicitly add requirement for python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,9 @@ rpm: buildrpm
 
 buildrpm: sdist
 	./setup.py bdist_rpm \
-		--release=`ls dist/*.noarch.rpm | wc -l`
+		--release=`ls dist/*.noarch.rpm | wc -l` \
+		--build-requires='python' \
+		--requires='python'
 
 deb: builddeb
 


### PR DESCRIPTION
I want to build Diamond using mock (for various reasons). When I tried it, the build failed because python was not installed in the mock chroot environment.

This change explicitly adds python as both a BuildRequires and Requires so the resulting SRPM can be built with mock.
