### PR TITLE
Port latency monitoring.

### DIFF
--- a/src/collectors/portlatency/portlatency.py
+++ b/src/collectors/portlatency/portlatency.py
@@ -35,10 +35,11 @@ We embed the name of the host in the metric string.
 """
 
 
-class PortLatency(diamond.collector.Collector):
+class PortLatencyCollector(diamond.collector.Collector):
 
     def get_default_config_help(self):
-        config_help = super(PortLacency, self).get_default_config_help()
+        config_help =
+            super(PortLatencyCollector, self).get_default_config_help()
         config.update({
             'path': 'portlatency',
         })
@@ -48,7 +49,7 @@ class PortLatency(diamond.collector.Collector):
         """
         Returns the default collector settings.
         """
-        config = super(PortLatency, self).get_default_config()
+        config = super(PortLatencyCollector, self).get_default_config()
         return config
 
     def collect(self):

--- a/src/collectors/portlatency/portlatency.py
+++ b/src/collectors/portlatency/portlatency.py
@@ -1,0 +1,77 @@
+import diamond.collector
+import os
+import socket
+from socket import error as socket_error
+import time
+
+"""
+Collect tcp or udp port opening times.
+
+##### Configuration
+
+Create a file called PortLatency.conf in the collectors_config_path
+directory.
+
+ * enabled = true
+ * interval = 60
+ * target_1 = www.yahoo.com:80:tcp
+ * target_2 = www.google.com:443:tcp
+ * target_3 = 8.8.8.8:53:udp
+
+Test your configuration using the following command:
+
+diamond-setup --print -C PortLatency
+
+You should get a reponse back that indicates 'enabled': True and see entries
+for your targets in pairs like:
+
+'target_1': 'www.yahoo.com:80:tcp'
+
+Where www.yahoo.com is the host, 80 is the port, and either tcp or udp is
+specified, all separated by colons.
+
+We embed the name of the host in the metric string.
+
+"""
+
+
+class PortLatency(diamond.collector.Collector):
+
+    def get_default_config_help(self):
+        config_help = super(PortLacency, self).get_default_config_help()
+        config.update({
+            'path': 'portlatency',
+        })
+        return config_help
+
+    def get_default_config(self):
+        """
+        Returns the default collector settings.
+        """
+        config = super(PortLatency, self).get_default_config()
+        return config
+
+    def collect(self):
+        for key in self.config.keys():
+            if key[:7] == "target_":
+                host, port, proto = self.config[key].split(':')
+                metric_name = host.replace('.', '_') + '.' + port + '.' + proto
+
+                if proto == 'tcp':
+                    sock = socket.socket()
+                elif proto == 'udp':
+                    sock = socket.socket(socket.SOCK_DGRAM)
+
+                port_failed = 0
+
+                time_start = time.time()
+                try:
+                    sock.connect((host, int(port)))
+                except socket_error as serr:
+                    port_failed = 1
+                time_end = time.time()
+
+                if port_failed:
+                    self.publish(metric_name, -1)
+                else:
+                    self.publish(metric_name, (time_end - time_start) * 1000)

--- a/src/collectors/portlatency/portlatency.py
+++ b/src/collectors/portlatency/portlatency.py
@@ -38,7 +38,7 @@ We embed the name of the host in the metric string.
 class PortLatencyCollector(diamond.collector.Collector):
 
     def get_default_config_help(self):
-        config_help =
+        config_help = \
             super(PortLatencyCollector, self).get_default_config_help()
         config.update({
             'path': 'portlatency',

--- a/src/collectors/portlatency/portlatency.py
+++ b/src/collectors/portlatency/portlatency.py
@@ -5,7 +5,8 @@ from socket import error as socket_error
 import time
 
 """
-Collect tcp or udp port opening times.
+Collect tcp or udp port opening times.  Useful for example if you need to
+monitor remote server API response times.
 
 ##### Configuration
 

--- a/src/collectors/portlatency/test/testportlatency.py
+++ b/src/collectors/portlatency/test/testportlatency.py
@@ -6,6 +6,8 @@ from test import CollectorTestCase
 from test import get_collector_config
 from portlatency import PortLatencyCollector
 
+################################################################################
+
 
 class TestPortLatencyCollector(CollectorTestCase):
     def setUp(self):

--- a/src/collectors/portlatency/test/testportlatency.py
+++ b/src/collectors/portlatency/test/testportlatency.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+# coding=utf-8
+################################################################################
+
+from test import CollectorTestCase
+from test import get_collector_config
+
+class TestPortLatencyCollector(CollectorTestCase):
+    def setUp(self):
+        config = get_collector_config('PortLatencyCollector', {})
+
+        self.collector = PortlatencyCollector(config, None)
+
+    def test_import(self):
+        self.assertTrue(PortLatencyCollector)

--- a/src/collectors/portlatency/test/testportlatency.py
+++ b/src/collectors/portlatency/test/testportlatency.py
@@ -4,12 +4,14 @@
 
 from test import CollectorTestCase
 from test import get_collector_config
+from portlatency import PortLatencyCollector
+
 
 class TestPortLatencyCollector(CollectorTestCase):
     def setUp(self):
         config = get_collector_config('PortLatencyCollector', {})
 
-        self.collector = PortlatencyCollector(config, None)
+        self.collector = PortLatencyCollector(config, None)
 
     def test_import(self):
         self.assertTrue(PortLatencyCollector)


### PR DESCRIPTION
For your consideration, please consider this new diamond module for measuring port latency.

We had a need to monitor both remote DNS and API calls.  Without getting into a functional examination of responses we simply wanted to know what the latency was in opening up a socket to the remote service.  That is what this module accomplishes.  It is not a particularly complicated module but for a subset of monitoring needs it does a good job.

If there are any refinements desired please let us know.
