### PR TITLE
Add 'rdsadmin' database in the blacklist of DatabaseStats

### DIFF
--- a/src/collectors/postgres/postgres.py
+++ b/src/collectors/postgres/postgres.py
@@ -256,7 +256,7 @@ class DatabaseStats(QueryStats):
         JOIN pg_stat_database
         ON pg_database.datname = pg_stat_database.datname
         WHERE pg_stat_database.datname
-        NOT IN ('template0','template1','postgres')
+        NOT IN ('template0','template1','postgres', 'rdsadmin')
     """
     query = post_92_query.replace(
         'pg_stat_database.temp_files as temp_files,',


### PR DESCRIPTION
I want to use this collector on a Amazon RDS database. The collector is failing because it has no permission to read the 'rdsadmin' database.
I don't have much idea how I should modify cleanly this plugin, but this modification works.
