### PR TITLE
Add process.open_file_descriptors metric to elasticsearch collector

### DIFF
--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -290,6 +290,8 @@ class ElasticSearchCollector(diamond.collector.Collector):
                          ['process', 'mem', 'share_in_bytes'])
         self._add_metric(metrics, 'process.mem.virtual', data,
                          ['process', 'mem', 'total_virtual_in_bytes'])
+        self._add_metric(metrics, 'process.open_file_descriptors', data,
+                         ['process', 'open_file_descriptors'])
 
         #
         # filesystem (may not be present, depending on access restrictions)

--- a/src/collectors/elasticsearch/test/testelasticsearch.py
+++ b/src/collectors/elasticsearch/test/testelasticsearch.py
@@ -88,6 +88,7 @@ class TestElasticSearchCollector(CollectorTestCase):
             'process.mem.resident': 5192126464,
             'process.mem.share': 11075584,
             'process.mem.virtual': 7109668864,
+            'process.open_file_descriptors': 2449,
 
             'disk.reads.count': 55996,
             'disk.reads.size': 1235387392,


### PR DESCRIPTION
The elasticsearch node stat endpoint also serves up a metric for open_file_descriptors, but the current elasticsearch endpoint doesn't collect it. I'm simply adding it to the collectors. Tests pass.
