### PR TITLE
Memcached stats collection fix

### DIFF
--- a/src/collectors/memcached/memcached.py
+++ b/src/collectors/memcached/memcached.py
@@ -124,7 +124,7 @@ class MemcachedCollector(diamond.collector.Collector):
             m = re.search("-c\x00(\d+)", f.readline())
             if m is not None:
                 self.log.debug('limit connections %s', m.group(1))
-                stats['limit_maxconn'] = m.group(1)
+                stats['limit_maxconn'] = int(m.group(1))
             f.close()
         except:
             self.log.debug("Cannot parse command line options for memcached")

--- a/src/collectors/memcached/memcached.py
+++ b/src/collectors/memcached/memcached.py
@@ -97,8 +97,7 @@ class MemcachedCollector(diamond.collector.Collector):
     def get_stats(self, host, port):
         # stuff that's always ignored, aren't 'stats'
         ignored = ('libevent', 'pointer_size', 'time', 'version',
-                   'repcached_version', 'replication', 'accepting_conns',
-                   'pid')
+                   'repcached_version', 'replication', 'accepting_conns')
         pid = None
 
         stats = {}


### PR DESCRIPTION
Fixed error as reported here https://github.com/BrightcoveOS/Diamond/issues/524 "Cannot parse command line options for memcached"

After which the get max connection limit also needs fixing to return and integer rather than a string.

Could/should possible rewrite this to get max connection limit from "stats settings" and avoid the need for the pid and reading from cmdline
