### PR TITLE
fixed bug of AttributeError: 'DiskSpaceCollector' object has no attribute 'filesystems'

### DIFF
--- a/src/collectors/diskspace/diskspace.py
+++ b/src/collectors/diskspace/diskspace.py
@@ -73,8 +73,9 @@ class DiskSpaceCollector(diamond.collector.Collector):
         })
         return config
 
-    def process_config(self):
-        super(DiskSpaceCollector, self).process_config()
+    def __init__(self, config, handlers):
+        super(DiskSpaceCollector, self).__init__(config, handlers)
+
         # Precompile things
         self.exclude_filters = self.config['exclude_filters']
         if isinstance(self.exclude_filters, basestring):


### PR DESCRIPTION

This pull request change fixes following bug in the diskspace.py collector:

[2015-04-01 11:05:22,310] [Thread-1] Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/diamond/collector.py", line 393, in _run
    self.collect()
  File "/usr/share/diamond/collectors/diskspace/diskspace.py", line 187, in collect
    results = self.get_file_systems()
  File "/usr/share/diamond/collectors/diskspace/diskspace.py", line 131, in get_file_systems
    if fs_type not in self.filesystems:
AttributeError: 'DiskSpaceCollector' object has no attribute 'filesystems' 