### PR TITLE
Increase precision for MySQL collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,3 @@ src/*.egg-info
 .tox
 gentoo/diamond-*.ebuild
 .vagrant
-
-*.swp
-
-*.un~

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ src/*.egg-info
 .tox
 gentoo/diamond-*.ebuild
 .vagrant
+
+*.swp
+
+*.un~

--- a/src/collectors/mysql/mysql.py
+++ b/src/collectors/mysql/mysql.py
@@ -407,7 +407,10 @@ class MySQLCollector(diamond.collector.Collector):
 
         return metrics
 
-    def _publish_stats(self, nickname, metrics):
+    def _publish_stats(self, nickname, metrics, precision=None):
+
+        if precision is None:
+          precision = self.config['precision'] or 4
 
         for key in metrics:
             for metric_name in metrics[key]:
@@ -422,9 +425,9 @@ class MySQLCollector(diamond.collector.Collector):
                 if key == 'status':
                     if ('publish' not in self.config
                             or metric_name in self.config['publish']):
-                        self.publish(nickname + metric_name, metric_value)
+                        self.publish(nickname + metric_name, metric_value, precision=precision)
                 else:
-                    self.publish(nickname + metric_name, metric_value)
+                    self.publish(nickname + metric_name, metric_value, precision=precision)
 
     def collect(self):
 

--- a/src/collectors/mysql/mysql.py
+++ b/src/collectors/mysql/mysql.py
@@ -44,6 +44,7 @@ except ImportError:
 class MySQLCollector(diamond.collector.Collector):
 
     _GAUGE_KEYS = [
+        'Innodb_buffer_pool_bytes_data', 'Innodb_buffer_pool_bytes_dirty',
         'Innodb_buffer_pool_pages_data', 'Innodb_buffer_pool_pages_dirty',
         'Innodb_buffer_pool_pages_free',
         'Innodb_buffer_pool_pages_misc', 'Innodb_buffer_pool_pages_total',
@@ -410,7 +411,12 @@ class MySQLCollector(diamond.collector.Collector):
     def _publish_stats(self, nickname, metrics, precision=None):
 
         if precision is None:
-          precision = self.config['precision'] or 4
+            if 'precision' in self.config:
+                if self.config['precision'] is not None:
+                    precision = int(self.config['precision'])
+        if precision is None:
+            precision = 4
+        self.log.error("Using precision %s" % precision)
 
         for key in metrics:
             for metric_name in metrics[key]:
@@ -425,9 +431,11 @@ class MySQLCollector(diamond.collector.Collector):
                 if key == 'status':
                     if ('publish' not in self.config
                             or metric_name in self.config['publish']):
-                        self.publish(nickname + metric_name, metric_value, precision=precision)
+                        self.publish(nickname + metric_name, metric_value, 
+                                     precision=precision)
                 else:
-                    self.publish(nickname + metric_name, metric_value, precision=precision)
+                    self.publish(nickname + metric_name, metric_value, 
+                                 precision=precision)
 
     def collect(self):
 

--- a/src/diamond/metric.py
+++ b/src/diamond/metric.py
@@ -68,7 +68,7 @@ class Metric(object):
         """
         Return the Metric as a string
         """
-        if not isinstance(self.precision, (int, long)):
+        if not isinstance(self.precision, (int, long, float)):
             log = logging.getLogger('diamond')
             log.warn('Metric %s does not have a valid precision', self.path)
             self.precision = 0


### PR DESCRIPTION
The MySQL Collector uses the default precision of 0.  This ends up truncating many of the metrics to 0. For instance, you'd have to have at least 60 slow queries per minion to get a blip in Grafana. This PR sets a default precision of 4 when calling self.publish() and makes the exact precision settable in /etc/diamond/collectors/MySQLCollector.conf.  It also adds a couple extra Innodb parameters.  We've been using it in production for months with no issues.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brightcoveos/diamond/813)

<!-- Reviewable:end -->
