### PR TITLE
zookeepercollector: remove obsolete fragment of memcached

### DIFF
--- a/src/collectors/zookeeper/zookeeper.py
+++ b/src/collectors/zookeeper/zookeeper.py
@@ -97,19 +97,6 @@ class ZookeeperCollector(diamond.collector.Collector):
                 continue
             stats[pieces[0]] = pieces[1]
 
-        # get max connection limit
-        self.log.debug('pid %s', pid)
-        try:
-            cmdline = "/proc/%s/cmdline" % pid
-            f = open(cmdline, 'r')
-            m = re.search("-c\x00(\d+)", f.readline())
-            if m is not None:
-                self.log.debug('limit connections %s', m.group(1))
-                stats['limit_maxconn'] = m.group(1)
-            f.close()
-        except:
-            self.log.debug("Cannot parse command line options for zookeeper")
-
         return stats
 
     def collect(self):


### PR DESCRIPTION
Just removing an unnecessary fragment left from the memcached copy. Acceptable?
