### PR TITLE
Enable captureWarning only in supported Python version

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -165,7 +165,8 @@ class Collector(object):
         Create a new instance of the Collector class
         """
         # Initialize Logger
-        logging.captureWarnings(True)
+        if hasattr(logging, 'captureWarnings'):
+            logging.captureWarnings(True)
         self.log = logging.getLogger('diamond')
         # Initialize Members
         if name is None:


### PR DESCRIPTION
With older Python versions, Diamond breaks with following error.

```
    logging.captureWarnings(True)
AttributeError: 'module' object has no attribute 'captureWarnings'
```

Following commit caused the regression.

```
commit a2bde9d38bca99e5d71371ac22ea74ea6cae7d83
Author: Mathieu Lecarme <mlecarme@bearstech.com>
Date:   Thu Oct 16 11:44:49 2014 +0200

    Some modules use the warnings API.

diff --git a/src/diamond/collector.py b/src/diamond/collector.py
index 9bf5593..2f76b46 100644
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -165,6 +165,7 @@ class Collector(object):
         Create a new instance of the Collector class
         """
         # Initialize Logger
+        logging.captureWarnings(True)
         self.log = logging.getLogger('diamond')
         # Initialize Members
         self.name = self.__class__.__name__
```
